### PR TITLE
Saving a file Epic 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ dodo**
 venv
 
 *storybook.log
+
+# Dev Environments
+src/environments/environment.development.ts

--- a/angular.json
+++ b/angular.json
@@ -55,7 +55,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/angular.json
+++ b/angular.json
@@ -33,9 +33,7 @@
             ],
             "styles": [
               "src/styles.scss",
-              "node_modules/primeng/resources/themes/lara-dark-blue/theme.css",
-              "node_modules/primeflex/primeflex.css",
-              "node_modules/primeng/resources/primeng.min.css"
+              "node_modules/primeng/resources/themes/lara-dark-blue/theme.css"
             ]
           },
           "configurations": {
@@ -92,9 +90,7 @@
             "port": 6006,
             "styles":[
               "src/styles.scss",
-              "node_modules/primeng/resources/themes/lara-dark-blue/theme.css",
-              "node_modules/primeflex/primeflex.css",
-              "node_modules/primeng/resources/primeng.min.css"
+              "node_modules/primeng/resources/themes/lara-dark-blue/theme.css"
             ]
           }
         },

--- a/documentation.json
+++ b/documentation.json
@@ -120,12 +120,12 @@
         },
         {
             "name": "OpenFileEvent",
-            "id": "interface-OpenFileEvent-b9b984d97f5e98f76e887466456fb0b0a97abb5888bcf5349c84fbfdd9207ce55ce39f421f037f26a2db47a53c27912a5b3fcd592cf11b3d21b600292946f2ec",
+            "id": "interface-OpenFileEvent-fdf2b1dc42006cf24f8f9e6e76f7dc4681a781861e07fd7606900cdff683e2ff948cef7096d3cb1ab13c0da0af2acc08a4d51b1e5dd50b723cc26a0b31cbb77f",
             "file": "src/app/modules/utilities/interfaces/Events.ts",
             "deprecated": false,
             "deprecationMessage": "",
             "type": "interface",
-            "sourceCode": "export interface OpenFileEvent \r\n{ file_name: string,\r\n     path: string \r\n    }",
+            "sourceCode": "export interface OpenFileEvent {\r\n  file_name: string;\r\n  path: string;\r\n}\r\n\r\nexport interface SaveFileEvent {\r\n     path?: string,\r\n     data?: string\r\n}\r\n\r\nexport interface TabChangeEvent {\r\n  path: string | undefined,\r\n  file: string\r\n}",
             "properties": [
                 {
                     "name": "file_name",
@@ -152,13 +152,46 @@
             "extends": []
         },
         {
+            "name": "SaveFileEvent",
+            "id": "interface-SaveFileEvent-fdf2b1dc42006cf24f8f9e6e76f7dc4681a781861e07fd7606900cdff683e2ff948cef7096d3cb1ab13c0da0af2acc08a4d51b1e5dd50b723cc26a0b31cbb77f",
+            "file": "src/app/modules/utilities/interfaces/Events.ts",
+            "deprecated": false,
+            "deprecationMessage": "",
+            "type": "interface",
+            "sourceCode": "export interface OpenFileEvent {\r\n  file_name: string;\r\n  path: string;\r\n}\r\n\r\nexport interface SaveFileEvent {\r\n     path?: string,\r\n     data?: string\r\n}\r\n\r\nexport interface TabChangeEvent {\r\n  path: string | undefined,\r\n  file: string\r\n}",
+            "properties": [
+                {
+                    "name": "data",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string",
+                    "optional": true,
+                    "description": "",
+                    "line": 8
+                },
+                {
+                    "name": "path",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string",
+                    "optional": true,
+                    "description": "",
+                    "line": 7
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 171,
+            "methods": [],
+            "extends": []
+        },
+        {
             "name": "Tab",
-            "id": "interface-Tab-c2daddeee09c309c904668d6fd71395d1e60f6f1f4674d2fc9c9d9e7e093c521556e52836f20758f3c74e52b768b581fb05dda7a6cee7193f74c522210b2965c",
+            "id": "interface-Tab-28c36d2fe860ebff683803ae245b3971ab919d21e535718c47c3ca3fdab6fc99908882e88cb201299b7e8c4260d9adf6c7a3407d2b3e2fef38c3e824b8840d41",
             "file": "src/app/modules/utilities/interfaces/Tab.ts",
             "deprecated": false,
             "deprecationMessage": "",
             "type": "interface",
-            "sourceCode": "export interface Tab{\r\n  id: number,\r\n  title: string,\r\n  isClosable: boolean,\r\n  selected: boolean,\r\n  path: string\r\n}\r\n",
+            "sourceCode": "export interface Tab{\r\n  id: number,\r\n  title: string,\r\n  isClosable: boolean,\r\n  selected: boolean,\r\n  path: string | undefined\r\n}\r\n",
             "properties": [
                 {
                     "name": "id",
@@ -182,7 +215,7 @@
                     "name": "path",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "type": "string",
+                    "type": "string | undefined",
                     "optional": false,
                     "description": "",
                     "line": 6
@@ -210,17 +243,50 @@
             "kind": 171,
             "methods": [],
             "extends": []
+        },
+        {
+            "name": "TabChangeEvent",
+            "id": "interface-TabChangeEvent-fdf2b1dc42006cf24f8f9e6e76f7dc4681a781861e07fd7606900cdff683e2ff948cef7096d3cb1ab13c0da0af2acc08a4d51b1e5dd50b723cc26a0b31cbb77f",
+            "file": "src/app/modules/utilities/interfaces/Events.ts",
+            "deprecated": false,
+            "deprecationMessage": "",
+            "type": "interface",
+            "sourceCode": "export interface OpenFileEvent {\r\n  file_name: string;\r\n  path: string;\r\n}\r\n\r\nexport interface SaveFileEvent {\r\n     path?: string,\r\n     data?: string\r\n}\r\n\r\nexport interface TabChangeEvent {\r\n  path: string | undefined,\r\n  file: string\r\n}",
+            "properties": [
+                {
+                    "name": "file",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 13
+                },
+                {
+                    "name": "path",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string | undefined",
+                    "optional": false,
+                    "description": "",
+                    "line": 12
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 171,
+            "methods": [],
+            "extends": []
         }
     ],
     "injectables": [
         {
             "name": "FolderTreeService",
-            "id": "injectable-FolderTreeService-7d6a2de5f1804a610ebf34fd40d570806f48376756fdd4b7329f7a785f8e2c93d15c754552b3a7604b962908648729636e1e58ab925cc607c8fe29cb07bcf2cb",
+            "id": "injectable-FolderTreeService-978621470f88f51b101b7fb9ca789badccdd96ab56e8f713c2b07cc9ef2827842da92fc367bdad458a2ec4221c4c6fc35f1808cfb9d18773b4c0a1c1aa4b0568",
             "file": "src/app/modules/ui-elements/folder-tree/folder-tree.service.ts",
             "properties": [
                 {
                     "name": "BASE_PATH",
-                    "defaultValue": "'D:\\\\OpenSourceSoftware\\\\rusty-notepad'",
+                    "defaultValue": "environment.current_directory",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "string",
@@ -369,7 +435,7 @@
             "deprecationMessage": "",
             "description": "",
             "rawdescription": "\n",
-            "sourceCode": "import { Injectable } from '@angular/core';\r\nimport { invoke } from '@tauri-apps/api';\r\nimport { DEFAULT_NODE, FileSystemItem, mapFileSystemItem2Node, mapFileSystemItem2NodeList, Node } from '../../utilities/interfaces/Node';\r\nimport { BehaviorSubject } from 'rxjs';\r\n\r\n@Injectable({\r\n  providedIn: 'root'\r\n})\r\nexport class FolderTreeService {\r\n\r\n  workspace = new BehaviorSubject<Node[]>([]);\r\n  rootNode = new BehaviorSubject<Node>(DEFAULT_NODE);\r\n  ROOT_NAME:string = '';\r\n  private BASE_PATH: string = 'D:\\\\OpenSourceSoftware\\\\rusty-notepad'\r\n\r\n  constructor() { }\r\n\r\n  initialize_Explorer(path: string = this.BASE_PATH) {\r\n    invoke<FileSystemItem[]>(\"read_directory\", { path }).then((directory_items: FileSystemItem[]) => {\r\n      let last_node = directory_items.pop()\r\n      if (last_node) {\r\n        let nodes_list = mapFileSystemItem2NodeList(directory_items, this.BASE_PATH);\r\n        this.rootNode.next({ ...mapFileSystemItem2Node(last_node), expanded: true })\r\n        this.workspace.next(nodes_list)\r\n        this.ROOT_NAME = last_node.file_name;       \r\n      }\r\n    });\r\n  }\r\n\r\n  openDirectory(workspace:Node[], index:number) {\r\n    if(!workspace[index].isDirectory)\r\n      return;\r\n    \r\n    if(!workspace[index].expanded && !workspace[index].nodes?.length)\r\n      this.expandDirectory(workspace[index]);\r\n    workspace[index].expanded = ! workspace[index].expanded\r\n\r\n  }\r\n\r\n  expandDirectory(folder: Node) {\r\n    let path = folder.path;\r\n    invoke<FileSystemItem[]>(\"read_directory\", { path }).then((items: FileSystemItem[]) => {\r\n      items.pop();\r\n      folder.expanded = true;\r\n      folder.nodes = mapFileSystemItem2NodeList(items, folder.path )      \r\n    })\r\n  }\r\n\r\n}\r\n",
+            "sourceCode": "import { Injectable } from '@angular/core';\r\nimport { invoke } from '@tauri-apps/api';\r\nimport { DEFAULT_NODE, FileSystemItem, mapFileSystemItem2Node, mapFileSystemItem2NodeList, Node } from '../../utilities/interfaces/Node';\r\nimport { BehaviorSubject } from 'rxjs';\r\nimport { environment } from '../../../../environments/environment';\r\n@Injectable({\r\n  providedIn: 'root'\r\n})\r\nexport class FolderTreeService {\r\n\r\n  workspace = new BehaviorSubject<Node[]>([]);\r\n  rootNode = new BehaviorSubject<Node>(DEFAULT_NODE);\r\n  ROOT_NAME: string = '';\r\n  private BASE_PATH: string = environment.current_directory\r\n\r\n  constructor() { }\r\n\r\n  initialize_Explorer(path: string = this.BASE_PATH) {\r\n    invoke<FileSystemItem[]>(\"read_directory\", { path }).then((directory_items: FileSystemItem[]) => {\r\n      let last_node = directory_items.pop()\r\n      if (last_node) {\r\n        let nodes_list = mapFileSystemItem2NodeList(directory_items, this.BASE_PATH);\r\n        this.rootNode.next({ ...mapFileSystemItem2Node(last_node), expanded: true })\r\n        this.workspace.next(nodes_list)\r\n        this.ROOT_NAME = last_node.file_name;\r\n      }\r\n    });\r\n  }\r\n\r\n  openDirectory(workspace: Node[], index: number) {\r\n    if (!workspace[index].isDirectory)\r\n      return;\r\n\r\n    if (!workspace[index].expanded && !workspace[index].nodes?.length)\r\n      this.expandDirectory(workspace[index]);\r\n    workspace[index].expanded = !workspace[index].expanded\r\n\r\n  }\r\n\r\n  expandDirectory(folder: Node) {\r\n    let path = folder.path;\r\n    invoke<FileSystemItem[]>(\"read_directory\", { path }).then((items: FileSystemItem[]) => {\r\n      items.pop();\r\n      folder.expanded = true;\r\n      folder.nodes = mapFileSystemItem2NodeList(items, folder.path)\r\n    })\r\n  }\r\n\r\n}\r\n",
             "constructorObj": {
                 "name": "constructor",
                 "description": "",
@@ -383,12 +449,12 @@
         },
         {
             "name": "ViewService",
-            "id": "injectable-ViewService-dcd754543cd696c1318f8ee1ac33a4346f79c802b563dfee83a9ee41ebbc1d03c49c5ac1389f1505519b40c7a88ba25d025cbbe23ad51eb5677fbb89072b19d3",
+            "id": "injectable-ViewService-4e67dfde6fe424c66003a42f57a60bd1c105dc432c8be8025b602a07b74e5929b2385443cfe095b3f901659ef2b3852414cef5b6fa4a42fe01df86edb21e0c0f",
             "file": "src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts",
             "properties": [
                 {
                     "name": "workbook$",
-                    "defaultValue": "new BehaviorSubject<String>('This is some default \\n work from an file')",
+                    "defaultValue": "new BehaviorSubject<string>(\r\n    'This is some default \\n work from an file',\r\n  )",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
@@ -399,11 +465,11 @@
             ],
             "methods": [
                 {
-                    "name": "convertFileLineEndings",
+                    "name": "readFile",
                     "args": [
                         {
-                            "name": "data",
-                            "type": "String",
+                            "name": "path",
+                            "type": "string | undefined",
                             "deprecated": false,
                             "deprecationMessage": ""
                         }
@@ -411,13 +477,13 @@
                     "optional": false,
                     "returnType": "any",
                     "typeParameters": [],
-                    "line": 22,
+                    "line": 16,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "jsdoctags": [
                         {
-                            "name": "data",
-                            "type": "String",
+                            "name": "path",
+                            "type": "string | undefined",
                             "deprecated": false,
                             "deprecationMessage": "",
                             "tagName": {
@@ -427,11 +493,11 @@
                     ]
                 },
                 {
-                    "name": "readFile",
+                    "name": "saveFile",
                     "args": [
                         {
-                            "name": "pathStr",
-                            "type": "String",
+                            "name": "file",
+                            "type": "SaveFileEvent",
                             "deprecated": false,
                             "deprecationMessage": ""
                         }
@@ -439,18 +505,35 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 14,
+                    "line": 39,
                     "deprecated": false,
                     "deprecationMessage": "",
+                    "rawdescription": "\n\nSaves the file contents on the choosen directory.\nIf the file is not present then creates the file with the specified name and then stores the content .\nIf the file is present it stores the content in the exsisting file\n",
+                    "description": "<p>Saves the file contents on the choosen directory.\nIf the file is not present then creates the file with the specified name and then stores the content .\nIf the file is present it stores the content in the exsisting file</p>\n",
                     "jsdoctags": [
                         {
-                            "name": "pathStr",
-                            "type": "String",
+                            "name": {
+                                "pos": 1309,
+                                "end": 1313,
+                                "flags": 16842752,
+                                "modifierFlagsCache": 0,
+                                "transformFlags": 0,
+                                "kind": 80,
+                                "escapedText": "file"
+                            },
+                            "type": "SaveFileEvent",
                             "deprecated": false,
                             "deprecationMessage": "",
                             "tagName": {
-                                "text": "param"
-                            }
+                                "pos": 1303,
+                                "end": 1308,
+                                "flags": 16842752,
+                                "modifierFlagsCache": 0,
+                                "transformFlags": 0,
+                                "kind": 80,
+                                "escapedText": "param"
+                            },
+                            "comment": ""
                         }
                     ]
                 }
@@ -459,14 +542,14 @@
             "deprecationMessage": "",
             "description": "",
             "rawdescription": "\n",
-            "sourceCode": "import { Injectable, signal } from '@angular/core';\r\nimport { invoke } from '@tauri-apps/api';\r\nimport { BehaviorSubject } from 'rxjs';\r\n\r\n@Injectable({\r\n  providedIn: 'root'\r\n})\r\nexport class ViewService {\r\n\r\n    workbook$ = new BehaviorSubject<String>('This is some default \\n work from an file')\r\n\r\n  constructor() { }\r\n\r\n  readFile(pathStr: String) {\r\n    if(pathStr == \".\") return;\r\n    invoke<String>(\"read_file\", { pathStr }).then((data:String) => {\r\n           ;\r\n           this.workbook$.next(this.convertFileLineEndings(data));\r\n    })\r\n  }\r\n\r\n  convertFileLineEndings(data: String){\r\n    let newdata = data.split(\"\\n\\r\").map((line) => `<p> ${line}`).join(\" \")\r\n    console.log(\"spliited data is \", newdata );\r\n    return newdata;\r\n  }\r\n\r\n}\r\n",
+            "sourceCode": "import { Injectable } from '@angular/core';\r\nimport { invoke } from '@tauri-apps/api';\r\nimport { BehaviorSubject } from 'rxjs';\r\nimport { SaveFileEvent } from '../../utilities/interfaces/Events';\r\n\r\n@Injectable({\r\n  providedIn: 'root',\r\n})\r\nexport class ViewService {\r\n  workbook$ = new BehaviorSubject<string>(\r\n    'This is some default \\n work from an file',\r\n  );\r\n\r\n  constructor() { }\r\n\r\n  readFile(path: string | undefined ) {\r\n    console.log(\"Reading file with path \", path);\r\n    \r\n    // If path is undefined the return with error log \r\n    if( !path ) console.error(\"Error while opening the file. Path undefined\", path);\r\n\r\n    // Some default values to be retured for current directory path . TODO Needs to verify if this is required or not :( \r\n    if (path == '.') return this.workbook$.next('This is some default \\n work from an file');\r\n\r\n    /**\r\n     * Reads the content of the file from the given path \r\n     */\r\n    invoke<string>('read_file', { path }).then((data: string) => {\r\n      this.workbook$.next(data);\r\n    });\r\n  }\r\n\r\n  /**\r\n   * Saves the file contents on the choosen directory.\r\n   * If the file is not present then creates the file with the specified name and then stores the content .\r\n   * If the file is present it stores the content in the exsisting file \r\n   * @param file \r\n   */\r\n  saveFile(file: SaveFileEvent) {\r\n    if (file.data && file.path) {\r\n      invoke<string>('save_file', { path: file.path, data: file.data }).then((res: string) => {\r\n        console.log(\"Response from the backend \", res);\r\n      })\r\n    }\r\n  }\r\n}\r\n",
             "constructorObj": {
                 "name": "constructor",
                 "description": "",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "args": [],
-                "line": 10
+                "line": 12
             },
             "extends": [],
             "type": "injectable"
@@ -891,7 +974,7 @@
         },
         {
             "name": "FolderComponent",
-            "id": "component-FolderComponent-27e6c06f8c9254c049fe4b27b5ae6fa0c5a70dee2fd56a3d3b4b92863fd6409f74278134b7106197648ba188248466ae926f90a3a4a00ecdf68b03ce895d4447",
+            "id": "component-FolderComponent-80aedb2ade249813d3e058e316bd4fd36852fa6fc2f9f4403ca083ce4ef617ca57b9107055613a0cd4d6023f8e630872f7ae66fe17ec3536506388a870729ab2",
             "file": "src/app/modules/ui-elements/folder-tree/folder/folder.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -912,12 +995,21 @@
                     "name": "folders",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 18,
+                    "line": 19,
                     "type": "Node[]",
                     "decorators": []
                 }
             ],
-            "outputsClass": [],
+            "outputsClass": [
+                {
+                    "name": "openFileEvent",
+                    "defaultValue": "new EventEmitter<OpenFileEvent>()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 21,
+                    "type": "EventEmitter"
+                }
+            ],
             "propertiesClass": [
                 {
                     "name": "fs",
@@ -926,13 +1018,57 @@
                     "type": "FolderTreeService",
                     "optional": false,
                     "description": "",
-                    "line": 20,
+                    "line": 23,
                     "modifierKind": [
                         125
                     ]
                 }
             ],
-            "methodsClass": [],
+            "methodsClass": [
+                {
+                    "name": "handleFileSystemClick",
+                    "args": [
+                        {
+                            "name": "folders",
+                            "type": "Node[]",
+                            "deprecated": false,
+                            "deprecationMessage": ""
+                        },
+                        {
+                            "name": "index",
+                            "type": "number",
+                            "deprecated": false,
+                            "deprecationMessage": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 26,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "jsdoctags": [
+                        {
+                            "name": "folders",
+                            "type": "Node[]",
+                            "deprecated": false,
+                            "deprecationMessage": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "index",
+                            "type": "number",
+                            "deprecated": false,
+                            "deprecationMessage": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
             "deprecated": false,
             "deprecationMessage": "",
             "hostBindings": [],
@@ -952,7 +1088,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { NgClass, NgFor, NgIf } from '@angular/common';\r\nimport { Component, Input } from '@angular/core';\r\nimport { Node } from '../../../utilities/interfaces/Node';\r\nimport { FolderTreeService } from '../folder-tree.service';\r\n\r\n@Component({\r\n  selector: 'rusty-folder',\r\n  standalone: true,\r\n  imports: [NgFor,NgIf,NgClass],\r\n  host: {\r\n    '[style.list-style-type]': \"none\"\r\n  },\r\n  templateUrl: './folder.component.html',\r\n  styleUrl: './folder.component.scss'\r\n})\r\nexport class FolderComponent {\r\n\r\n  @Input() folders!:Node[];\r\n\r\n  constructor(public fs:FolderTreeService){\r\n\r\n  }\r\n}\r\n",
+            "sourceCode": "import { NgClass, NgFor, NgIf } from '@angular/common';\r\nimport { Component, EventEmitter, Input, Output } from '@angular/core';\r\nimport { Node } from '../../../utilities/interfaces/Node';\r\nimport { FolderTreeService } from '../folder-tree.service';\r\nimport { OpenFileEvent } from '../../../utilities/interfaces/Events';\r\n\r\n@Component({\r\n  selector: 'rusty-folder',\r\n  standalone: true,\r\n  imports: [NgFor,NgIf,NgClass],\r\n  host: {\r\n    '[style.list-style-type]': \"none\"\r\n  },\r\n  templateUrl: './folder.component.html',\r\n  styleUrl: './folder.component.scss'\r\n})\r\nexport class FolderComponent {\r\n\r\n  @Input() folders!:Node[];\r\n\r\n  @Output() openFileEvent = new EventEmitter<OpenFileEvent>()\r\n\r\n  constructor(public fs:FolderTreeService){\r\n  }\r\n\r\n  handleFileSystemClick(folders: Node[], index: number) {\r\n    if (folders[index].isDirectory)\r\n      this.fs.openDirectory(folders, index);\r\n    else\r\n      this.openFileEvent.emit({\r\n        file_name: folders[index].name,\r\n        path: folders[index].path,\r\n      });\r\n  }\r\n}\r\n",
             "styleUrl": "./folder.component.scss",
             "assetsDirs": [],
             "styleUrlsData": "",
@@ -970,7 +1106,7 @@
                         "deprecationMessage": ""
                     }
                 ],
-                "line": 18,
+                "line": 21,
                 "jsdoctags": [
                     {
                         "name": "fs",
@@ -984,11 +1120,11 @@
                 ]
             },
             "extends": [],
-            "templateData": "<li class=\"my-1\" *ngFor=\"let folder of folders;index as i\">\r\n  <span (click)=\"this.fs.openDirectory(folders,i)\" class=\"flex items-center item\">\r\n    <i style=\"font-size: 12px; align-content: end; margin-right: 3px;\" *ngIf=\"folder.isDirectory\" class=\"pi\" [ngClass]=\"\r\n    folder.expanded ? 'pi-angle-down' : 'pi-angle-right'\r\n  \"></i> {{folder.name}}\r\n  </span>\r\n  <ul style=\"padding-left: .7rem;\">\r\n    <rusty-folder *ngIf=\"folder.nodes && folder.expanded\" [folders]=\"folder.nodes\" />\r\n  </ul>\r\n</li>\r\n"
+            "templateData": "<li class=\"py-1 item\" *ngFor=\"let folder of folders;index as i\">\r\n  <span (click)=\"this.handleFileSystemClick(folders, i)\" class=\"flex items-center\" [ngClass]=\"folder.isDirectory ? '' : 'ml-1 mt-1'\">\r\n    <i style=\"font-size: 12px; align-content: end; margin-right: 3px;\" *ngIf=\"folder.isDirectory\" class=\"pi\" [ngClass]=\"\r\n    folder.expanded ? 'pi-angle-down' : 'pi-angle-right'\r\n  \"></i> {{folder.name}}\r\n  </span>\r\n  <ul style=\"padding-left: .7rem;\">\r\n    <rusty-folder *ngIf=\"folder.nodes && folder.expanded\" [folders]=\"folder.nodes\" />\r\n  </ul>\r\n</li>\r\n"
         },
         {
             "name": "FolderTreeComponent",
-            "id": "component-FolderTreeComponent-9c6386f05cc342a5f8cd2453cb607559888d5ef81272873eeaba18acc7637cd0c37333763813558ea50d401f248417db8b97b956899e0a55eb546a7874cbd931",
+            "id": "component-FolderTreeComponent-4d30a2a30f84ff3b2a63a1ee1babf93e6ddc5ac8a944164259fd1aa7469835b2e66cecc66f5d4a1a3e832dd933705457b61b7e2a06fe5d0cb0dc590ed5eccaba",
             "file": "src/app/modules/ui-elements/folder-tree/folder-tree.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1010,7 +1146,7 @@
                     "defaultValue": "new EventEmitter<OpenFileEvent>()",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 17,
+                    "line": 18,
                     "type": "EventEmitter"
                 }
             ],
@@ -1022,7 +1158,7 @@
                     "type": "FolderTreeService",
                     "optional": false,
                     "description": "",
-                    "line": 24,
+                    "line": 25,
                     "modifierKind": [
                         125
                     ]
@@ -1034,7 +1170,7 @@
                     "type": "Node",
                     "optional": false,
                     "description": "",
-                    "line": 21
+                    "line": 22
                 },
                 {
                     "name": "root$",
@@ -1043,7 +1179,7 @@
                     "type": "Subscription",
                     "optional": false,
                     "description": "",
-                    "line": 22
+                    "line": 23
                 },
                 {
                     "name": "workspace",
@@ -1052,7 +1188,7 @@
                     "type": "Node[]",
                     "optional": false,
                     "description": "",
-                    "line": 18
+                    "line": 19
                 },
                 {
                     "name": "workspace$",
@@ -1061,7 +1197,7 @@
                     "type": "Subscription",
                     "optional": false,
                     "description": "",
-                    "line": 19
+                    "line": 20
                 }
             ],
             "methodsClass": [
@@ -1078,7 +1214,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 39,
+                    "line": 40,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "jsdoctags": [
@@ -1094,12 +1230,40 @@
                     ]
                 },
                 {
+                    "name": "handleNestedFileOpenEvent",
+                    "args": [
+                        {
+                            "name": "event",
+                            "type": "OpenFileEvent",
+                            "deprecated": false,
+                            "deprecationMessage": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 50,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "jsdoctags": [
+                        {
+                            "name": "event",
+                            "type": "OpenFileEvent",
+                            "deprecated": false,
+                            "deprecationMessage": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "ngOnDestroy",
                     "args": [],
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 34,
+                    "line": 35,
                     "deprecated": false,
                     "deprecationMessage": ""
                 }
@@ -1131,7 +1295,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { NgClass, NgFor, NgIf, UpperCasePipe } from '@angular/common';\r\nimport { Component, EventEmitter, OnDestroy, Output } from '@angular/core';\r\nimport { FolderComponent } from './folder/folder.component';\r\nimport { FolderTreeService } from './folder-tree.service';\r\nimport { Subscription } from 'rxjs';\r\nimport { Node } from '../../utilities/interfaces/Node';\r\nimport { OpenFileEvent } from '../../utilities/interfaces/Events';\r\n\r\n@Component({\r\n  selector: 'rusty-folder-tree',\r\n  standalone: true,\r\n  imports: [NgIf, NgFor, NgClass, FolderComponent, UpperCasePipe],\r\n  templateUrl: './folder-tree.component.html',\r\n  styleUrl: './folder-tree.component.scss',\r\n})\r\nexport class FolderTreeComponent implements OnDestroy {\r\n  @Output() openFileEvent = new EventEmitter<OpenFileEvent>();\r\n  workspace!: Node[];\r\n  workspace$!: Subscription;\r\n\r\n  root!: Node;\r\n  root$!: Subscription;\r\n\r\n  constructor(public fsService: FolderTreeService) {\r\n    this.workspace$ = this.fsService.workspace.subscribe((ele: Node[]) => {\r\n      this.workspace = ele;\r\n    });\r\n    this.root$ = this.fsService.rootNode.subscribe((ele: Node) => {\r\n      this.root = ele;\r\n    });\r\n    this.fsService.initialize_Explorer();\r\n  }\r\n\r\n  ngOnDestroy(): void {\r\n    this.workspace$.unsubscribe();\r\n    this.root$.unsubscribe();\r\n  }\r\n\r\n  handleFileSystemClick(index: number) {\r\n    if (this.workspace[index].isDirectory)\r\n      this.fsService.openDirectory(this.workspace, index);\r\n    else\r\n      this.openFileEvent.emit({\r\n        file_name: this.workspace[index].name,\r\n        path: this.workspace[index].path,\r\n      });\r\n  }\r\n}\r\n",
+            "sourceCode": "import { NgClass, NgFor, NgIf, UpperCasePipe } from '@angular/common';\r\nimport { Component, EventEmitter, OnDestroy, Output } from '@angular/core';\r\nimport { FolderComponent } from './folder/folder.component';\r\nimport { FolderTreeService } from './folder-tree.service';\r\nimport { Subscription } from 'rxjs';\r\nimport { Node } from '../../utilities/interfaces/Node';\r\nimport { OpenFileEvent } from '../../utilities/interfaces/Events';\r\n\r\n@Component({\r\n  selector: 'rusty-folder-tree',\r\n  standalone: true,\r\n  imports: [NgIf, NgFor, NgClass, FolderComponent, UpperCasePipe],\r\n  templateUrl: './folder-tree.component.html',\r\n  styleUrl: './folder-tree.component.scss',\r\n})\r\nexport class FolderTreeComponent implements OnDestroy {\r\n\r\n  @Output() openFileEvent = new EventEmitter<OpenFileEvent>();\r\n  workspace!: Node[];\r\n  workspace$!: Subscription;\r\n\r\n  root!: Node;\r\n  root$!: Subscription;\r\n\r\n  constructor(public fsService: FolderTreeService) {\r\n    this.workspace$ = this.fsService.workspace.subscribe((ele: Node[]) => {\r\n      this.workspace = ele;\r\n    });\r\n    this.root$ = this.fsService.rootNode.subscribe((ele: Node) => {\r\n      this.root = ele;\r\n    });\r\n    this.fsService.initialize_Explorer();\r\n  }\r\n\r\n  ngOnDestroy(): void {\r\n    this.workspace$.unsubscribe();\r\n    this.root$.unsubscribe();\r\n  }\r\n\r\n  handleFileSystemClick(index: number) {\r\n    if (this.workspace[index].isDirectory)\r\n      this.fsService.openDirectory(this.workspace, index);\r\n    else\r\n      this.openFileEvent.emit({\r\n        file_name: this.workspace[index].name,\r\n        path: this.workspace[index].path,\r\n      });\r\n  }\r\n\r\n  handleNestedFileOpenEvent(event: OpenFileEvent) {\r\n    console.log(\"this got called \", event);\r\n    \r\n    this.openFileEvent.emit(event);\r\n  }\r\n}\r\n",
             "styleUrl": "./folder-tree.component.scss",
             "assetsDirs": [],
             "styleUrlsData": "",
@@ -1149,7 +1313,7 @@
                         "deprecationMessage": ""
                     }
                 ],
-                "line": 22,
+                "line": 23,
                 "jsdoctags": [
                     {
                         "name": "fsService",
@@ -1166,7 +1330,7 @@
             "implements": [
                 "OnDestroy"
             ],
-            "templateData": "<ul class=\"my-0\" style=\"padding: 2px 0px 0px 3px;\">\r\n  <li class=\"my-1\">\r\n    <span (click)=\"root.expanded = !root.expanded\" class=\"flex items-center item\" style=\"font-weight: 500;\">\r\n      <i  style=\"font-size: 12px; align-content: end; margin-right: 3px;\" class=\"pi\"\r\n        [ngClass]=\"root.expanded ? 'pi-angle-down' : 'pi-angle-right'\"></i>\r\n      {{ root.name | uppercase}}\r\n    </span>\r\n\r\n    <ul *ngIf=\"root.expanded\" style=\"padding-left: .7rem;\">\r\n      <li class=\"my-1\" *ngFor=\"let fileSystemItem of workspace; index as i\">\r\n        <span (click)=\"this.handleFileSystemClick(i)\" class=\"flex items-center item\"\r\n          [ngClass]=\"fileSystemItem.isDirectory ? '' : 'ml-2'\">\r\n          <i style=\"font-size: 12px; align-content: end; margin-right: 3px;\" *ngIf=\"fileSystemItem.isDirectory\" class=\"pi\" [ngClass]=\"\r\n              fileSystemItem.expanded ? 'pi-angle-down' : 'pi-angle-right'\r\n            \"></i>\r\n          {{ fileSystemItem.name }}\r\n        </span>\r\n        <ul *ngIf=\"fileSystemItem.expanded\" style=\"padding-left: .7rem;\">\r\n          <rusty-folder *ngIf=\"fileSystemItem.nodes\" [folders]=\"fileSystemItem.nodes\" />\r\n        </ul>\r\n      </li>\r\n    </ul>\r\n  </li>\r\n</ul>\r\n"
+            "templateData": "<ul class=\"my-0\" style=\"padding: 2px 0px 0px 3px;\">\r\n  <li class=\"py-1\">\r\n    <span (click)=\"root.expanded = !root.expanded\" class=\"flex items-center item\" style=\"font-weight: 500;\">\r\n      <i  style=\"font-size: 12px; align-content: end; margin-right: 3px;\" class=\"pi\"\r\n        [ngClass]=\"root.expanded ? 'pi-angle-down' : 'pi-angle-right'\"></i>\r\n      {{ root.name | uppercase}}\r\n    </span>\r\n\r\n    <ul *ngIf=\"root.expanded\" style=\"padding-left: .7rem;\">\r\n      <li class=\"py-1 item\" *ngFor=\"let fileSystemItem of workspace; index as i\">\r\n        <span (click)=\"this.handleFileSystemClick(i)\" class=\"flex items-center \"\r\n          [ngClass]=\"fileSystemItem.isDirectory ? '' : 'ml-2'\">\r\n          <i style=\"font-size: 12px; align-content: end; margin-right: 3px;\" *ngIf=\"fileSystemItem.isDirectory\" class=\"pi\" [ngClass]=\"\r\n              fileSystemItem.expanded ? 'pi-angle-down' : 'pi-angle-right'\r\n            \"></i>\r\n          {{ fileSystemItem.name }}\r\n        </span>\r\n        <ul *ngIf=\"fileSystemItem.expanded\" style=\"padding-left: .7rem;\">\r\n          <rusty-folder (openFileEvent)=\"handleNestedFileOpenEvent($event)\" *ngIf=\"fileSystemItem.nodes\" [folders]=\"fileSystemItem.nodes\" />\r\n        </ul>\r\n      </li>\r\n    </ul>\r\n  </li>\r\n</ul>\r\n"
         },
         {
             "name": "HorizontalBarComponent",
@@ -1208,7 +1372,7 @@
         },
         {
             "name": "RustyViewComponent",
-            "id": "component-RustyViewComponent-26f500d960da0c6d044682056294d09b80d8439988e5f5301dda1ed354931ba3015cbb6a23925288669196d6d2520af9fc4725a3883af9b6b20ffe8ae96195d1",
+            "id": "component-RustyViewComponent-2a9ac73c8a1004a7db3647808cac38dfd5328e086cb20001176ef07438a80559e4f3eef4791673aa52659c28d47d5f8c563ecae94b63003cedfb18b54d1c2784",
             "file": "src/app/modules/ui-elements/rusty-view/rusty-view.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1227,13 +1391,43 @@
             "outputsClass": [],
             "propertiesClass": [
                 {
+                    "name": "currentFileName",
+                    "defaultValue": "\"\"",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 29
+                },
+                {
+                    "name": "currentWorkingDirectory",
+                    "defaultValue": "environment.current_directory",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 28
+                },
+                {
                     "name": "workfile",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "type": "String",
+                    "type": "string",
                     "optional": false,
                     "description": "",
-                    "line": 18
+                    "line": 25
+                },
+                {
+                    "name": "workfilePath",
+                    "defaultValue": "undefined",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string | undefined",
+                    "optional": false,
+                    "description": "",
+                    "line": 27
                 },
                 {
                     "name": "workFileSubs",
@@ -1242,16 +1436,16 @@
                     "type": "Subscription",
                     "optional": false,
                     "description": "",
-                    "line": 19
+                    "line": 26
                 }
             ],
             "methodsClass": [
                 {
-                    "name": "updateWorkpad",
+                    "name": "saveCurrentFile",
                     "args": [
                         {
-                            "name": "path",
-                            "type": "string",
+                            "name": "event",
+                            "type": "SaveFileEvent",
                             "deprecated": false,
                             "deprecationMessage": ""
                         }
@@ -1259,13 +1453,41 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 28,
+                    "line": 43,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "jsdoctags": [
                         {
-                            "name": "path",
-                            "type": "string",
+                            "name": "event",
+                            "type": "SaveFileEvent",
+                            "deprecated": false,
+                            "deprecationMessage": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "updateWorkpad",
+                    "args": [
+                        {
+                            "name": "tabChangeEvent",
+                            "type": "TabChangeEvent",
+                            "deprecated": false,
+                            "deprecationMessage": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 37,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "jsdoctags": [
+                        {
+                            "name": "tabChangeEvent",
+                            "type": "TabChangeEvent",
                             "deprecated": false,
                             "deprecationMessage": "",
                             "tagName": {
@@ -1301,7 +1523,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, computed } from '@angular/core';\r\nimport { TabsComponent } from \"../tabs/tabs.component\";\r\nimport { WorkpadComponent } from '../workpad/workpad.component';\r\nimport { SplitterComponent } from \"../splitter/splitter.component\";\r\nimport { FolderTreeComponent } from \"../folder-tree/folder-tree.component\";\r\nimport { ViewService } from './rusty-vew.service';\r\nimport { Subscription } from 'rxjs';\r\n\r\n@Component({\r\n  selector: 'app-rusty-view',\r\n  templateUrl: './rusty-view.component.html',\r\n  styleUrl: './rusty-view.component.scss',\r\n  standalone: true,\r\n  imports: [TabsComponent, WorkpadComponent, SplitterComponent, FolderTreeComponent]\r\n})\r\nexport class RustyViewComponent {\r\n\r\nworkfile!: String;\r\nworkFileSubs: Subscription;\r\n\r\n\r\nconstructor(private viewService:ViewService){\r\n  this.workFileSubs = this.viewService.workbook$.subscribe((data)=>{\r\n    this.workfile = data ;\r\n  })\r\n}\r\n\r\nupdateWorkpad(path: string) {\r\n  this.viewService.readFile(path);\r\n}\r\n\r\n}\r\n",
+            "sourceCode": "import { Component } from '@angular/core';\r\nimport { TabsComponent } from '../tabs/tabs.component';\r\nimport { WorkpadComponent } from '../workpad/workpad.component';\r\nimport { SplitterComponent } from '../splitter/splitter.component';\r\nimport { FolderTreeComponent } from '../folder-tree/folder-tree.component';\r\nimport { ViewService } from './rusty-vew.service';\r\nimport { Subscription } from 'rxjs';\r\nimport { SaveFileEvent, TabChangeEvent } from '../../utilities/interfaces/Events';\r\nimport { save } from '@tauri-apps/api/dialog';\r\nimport { environment } from '../../../../environments/environment';\r\n\r\n@Component({\r\n  selector: 'app-rusty-view',\r\n  templateUrl: './rusty-view.component.html',\r\n  styleUrl: './rusty-view.component.scss',\r\n  standalone: true,\r\n  imports: [\r\n    TabsComponent,\r\n    WorkpadComponent,\r\n    SplitterComponent,\r\n    FolderTreeComponent,\r\n  ],\r\n})\r\nexport class RustyViewComponent {\r\n  workfile!: string;\r\n  workFileSubs: Subscription;\r\n  workfilePath: string | undefined = undefined;\r\n  currentWorkingDirectory: string = environment.current_directory;\r\n  currentFileName:string = \"\";\r\n\r\n  constructor(private viewService: ViewService) {\r\n    this.workFileSubs = this.viewService.workbook$.subscribe((data) => {\r\n      this.workfile = data;\r\n    });\r\n  }\r\n\r\n  updateWorkpad(tabChangeEvent: TabChangeEvent) {\r\n    this.workfilePath = tabChangeEvent.path;\r\n    this.currentFileName = tabChangeEvent.file;\r\n    this.viewService.readFile(tabChangeEvent.path);\r\n  }\r\n\r\n  saveCurrentFile(event: SaveFileEvent) {\r\n    /**\r\n     * If current workfile path is not present , then open save dialog on save event \r\n     */\r\n    if (!this.workfilePath) {\r\n      save({ defaultPath: this.currentWorkingDirectory, title: \"Save As\"})\r\n        .then((saveFilePath) => {\r\n          console.log(\"save file path \", saveFilePath);\r\n          if (saveFilePath) {\r\n            this.workfilePath = saveFilePath;\r\n            this.viewService.saveFile({ ...event, path: saveFilePath as string } as SaveFileEvent);\r\n          }\r\n        })\r\n    }\r\n    else {\r\n      this.viewService.saveFile({ ...event, path: this.workfilePath } as SaveFileEvent);\r\n    }\r\n  }\r\n}\r\n",
             "styleUrl": "./rusty-view.component.scss",
             "assetsDirs": [],
             "styleUrlsData": "",
@@ -1319,7 +1541,7 @@
                         "deprecationMessage": ""
                     }
                 ],
-                "line": 19,
+                "line": 29,
                 "jsdoctags": [
                     {
                         "name": "viewService",
@@ -1333,7 +1555,7 @@
                 ]
             },
             "extends": [],
-            "templateData": "<div class=\"layout h-full\">\r\n  <!--  Add a Folders option on left side  -->\r\n  <app-splitter class=\"h-full\">\r\n    <div >\r\n      <rusty-folder-tree (openFileEvent)=\"tabs.newTab($event)\"></rusty-folder-tree>\r\n    </div>\r\n    <app-tabs #tabs panel2 (activeTabChangeEvent)=\"updateWorkpad($event)\"></app-tabs>\r\n    <app-workpad panel2 [contentFromFile]=\"workfile\"></app-workpad>\r\n\r\n  </app-splitter>\r\n</div>\r\n"
+            "templateData": "<div class=\"layout h-full\">\r\n  <!--  Add a Folders option on left side  -->\r\n  <app-splitter class=\"h-full\">\r\n    <div >\r\n      <rusty-folder-tree (openFileEvent)=\"tabs.newTab($event)\"></rusty-folder-tree>\r\n    </div>\r\n    <app-tabs #tabs panel2 (activeTabChangeEvent)=\"updateWorkpad($event)\"></app-tabs>\r\n    <app-workpad panel2 (saveFileEvent)=\"saveCurrentFile($event)\" [contentFromFile]=\"workfile\"></app-workpad>\r\n\r\n  </app-splitter>\r\n</div>\r\n"
         },
         {
             "name": "SplitterComponent",
@@ -1384,7 +1606,7 @@
         },
         {
             "name": "TabsComponent",
-            "id": "component-TabsComponent-78b100cbc9fff694e788cf5bb47610a4b21b1e2d67c18ff959a860aab867c9f1a6ba0a5a302e81334047fc8bc98f7f3cb2496dda38f44825fbae5047e140ea6a",
+            "id": "component-TabsComponent-db7c8251159162571683399dcc01e692e762223fc29c72ca53e2b674ba7eac8f228169eedb177c0932432a8aac69e2c85f5329900a4333d5c30d4429ce90aff6",
             "file": "src/app/modules/ui-elements/tabs/tabs.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1407,7 +1629,7 @@
                     "deprecationMessage": "",
                     "rawdescription": "\n\nThis takes a list of tabs from the service which reads all the files\n",
                     "description": "<p>This takes a list of tabs from the service which reads all the files</p>\n",
-                    "line": 34,
+                    "line": 33,
                     "type": "Tab[]",
                     "decorators": []
                 }
@@ -1415,10 +1637,10 @@
             "outputsClass": [
                 {
                     "name": "activeTabChangeEvent",
-                    "defaultValue": "new EventEmitter<string>()",
+                    "defaultValue": "new EventEmitter<TabChangeEvent>()",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 24,
+                    "line": 23,
                     "type": "EventEmitter"
                 }
             ],
@@ -1431,7 +1653,7 @@
                     "type": "number",
                     "optional": false,
                     "description": "<p>This is use to toggle active tab on Ctrl + Tab event</p>\n",
-                    "line": 29,
+                    "line": 28,
                     "rawdescription": "\n\nThis is use to toggle active tab on Ctrl + Tab event\n",
                     "modifierKind": [
                         125
@@ -1445,7 +1667,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 48,
+                    "line": 46,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "rawdescription": "\n\nSwitch to next Tab on control + tab event\n",
@@ -1466,7 +1688,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 74,
+                    "line": 72,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "decorators": [
@@ -1492,7 +1714,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 56,
+                    "line": 54,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "rawdescription": "\n\nNew Tab on Ctrl + N\n",
@@ -1510,12 +1732,12 @@
                     ]
                 },
                 {
-                    "name": "ngAfterViewInit",
+                    "name": "ngOnInit",
                     "args": [],
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 36,
+                    "line": 35,
                     "deprecated": false,
                     "deprecationMessage": ""
                 },
@@ -1533,7 +1755,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 82,
+                    "line": 80,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "jsdoctags": [
@@ -1560,7 +1782,7 @@
                     "argsDecorator": [],
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 74
+                    "line": 72
                 },
                 {
                     "name": "document:keydown.control.tab",
@@ -1570,7 +1792,7 @@
                     "deprecationMessage": "",
                     "rawdescription": "\n\nSwitch to next Tab on control + tab event\n",
                     "description": "<p>Switch to next Tab on control + tab event</p>\n",
-                    "line": 48
+                    "line": 46
                 }
             ],
             "standalone": true,
@@ -1594,14 +1816,14 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import {\r\n  AfterViewInit,\r\n  Component,\r\n  EventEmitter,\r\n  HostListener,\r\n  Input,\r\n  OnInit,\r\n  Output,\r\n} from '@angular/core';\r\nimport { TabViewModule } from 'primeng/tabview';\r\nimport { CommonModule, NgFor } from '@angular/common';\r\nimport { WorkpadComponent } from '../workpad/workpad.component';\r\nimport { Tab } from '../../utilities/interfaces/Tab';\r\nimport { NEW_TAB_DEFAULT } from '../../utilities/Constants';\r\nimport { OpenFileEvent } from '../../utilities/interfaces/Events';\r\n@Component({\r\n  selector: 'app-tabs',\r\n  templateUrl: './tabs.component.html',\r\n  styleUrl: './tabs.component.scss',\r\n  standalone: true,\r\n  imports: [CommonModule, TabViewModule, WorkpadComponent, NgFor],\r\n})\r\nexport class TabsComponent implements AfterViewInit{\r\n  @Output() activeTabChangeEvent = new EventEmitter<string>();\r\n\r\n  /**\r\n   * This is use to toggle active tab on Ctrl + Tab event\r\n   */\r\n  public activeIndex: number = 0;\r\n\r\n  /**\r\n   * This takes a list of tabs from the service which reads all the files\r\n   */\r\n  @Input('tabs') tabs: Tab[] = []; \r\n\r\n  ngAfterViewInit(): void {\r\n    console.log(\"View init complete \", this.tabs.length);\r\n    if(this.tabs.length == 0){\r\n      this.tabs.push({...NEW_TAB_DEFAULT, id:0})\r\n      this.activeIndex = 0;\r\n      this.tabs[0].selected = true\r\n    }\r\n  }\r\n  /**\r\n   * Switch to next Tab on control + tab event\r\n   */\r\n  @HostListener('document:keydown.control.tab')\r\n  changeTab() {\r\n    this.activeIndex = (this.activeIndex + 1) % this.tabs.length;\r\n    this.triggerTabChangeEvent(this.activeIndex);\r\n  }\r\n\r\n  /**\r\n   * New Tab on Ctrl + N\r\n   */\r\n  newTab(tabEvent: OpenFileEvent) {\r\n    if (!tabEvent.file_name) this.createBlankTab();\r\n    if (!tabEvent.path) this.createBlankTab();\r\n\r\n    let newTab: Tab = {\r\n      ...NEW_TAB_DEFAULT,\r\n      id: this.tabs.length,\r\n      title: tabEvent.file_name,\r\n      path: tabEvent.path,\r\n    };\r\n\r\n    this.tabs.push(newTab);\r\n    this.tabs[this.activeIndex].selected = false;\r\n    this.activeIndex = newTab.id;\r\n    this.triggerTabChangeEvent(this.activeIndex);\r\n  }\r\n\r\n  @HostListener('document:keydown.control.N')\r\n  createBlankTab() {\r\n    let newTab: Tab = { ...NEW_TAB_DEFAULT, id: this.tabs.length };\r\n    this.tabs.push(newTab);\r\n    this.tabs[this.activeIndex].selected = false;\r\n    this.activeIndex = newTab.id;\r\n    this.triggerTabChangeEvent(this.activeIndex);\r\n  }\r\n\r\n  triggerTabChangeEvent(index: number = 0) {\r\n    if (this.tabs?.length)\r\n      this.activeTabChangeEvent.emit(this.tabs[index].path);\r\n  }\r\n}\r\n",
+            "sourceCode": "import {\r\n  Component,\r\n  EventEmitter,\r\n  HostListener,\r\n  Input,\r\n  OnInit,\r\n  Output,\r\n} from '@angular/core';\r\nimport { TabViewModule } from 'primeng/tabview';\r\nimport { CommonModule, NgFor } from '@angular/common';\r\nimport { WorkpadComponent } from '../workpad/workpad.component';\r\nimport { Tab } from '../../utilities/interfaces/Tab';\r\nimport { NEW_TAB_DEFAULT } from '../../utilities/Constants';\r\nimport { OpenFileEvent, TabChangeEvent } from '../../utilities/interfaces/Events';\r\n@Component({\r\n  selector: 'app-tabs',\r\n  templateUrl: './tabs.component.html',\r\n  styleUrl: './tabs.component.scss',\r\n  standalone: true,\r\n  imports: [CommonModule, TabViewModule, WorkpadComponent, NgFor],\r\n})\r\nexport class TabsComponent implements OnInit{\r\n  @Output() activeTabChangeEvent = new EventEmitter<TabChangeEvent>();\r\n\r\n  /**\r\n   * This is use to toggle active tab on Ctrl + Tab event\r\n   */\r\n  public activeIndex: number = 0;\r\n\r\n  /**\r\n   * This takes a list of tabs from the service which reads all the files\r\n   */\r\n  @Input('tabs') tabs: Tab[] = []; \r\n\r\n  ngOnInit(): void {\r\n    if(this.tabs.length == 0){\r\n      this.tabs.push({...NEW_TAB_DEFAULT, id:0})\r\n      this.activeIndex = 0;\r\n      this.tabs[0].selected = true\r\n    }\r\n  }\r\n  /**\r\n   * Switch to next Tab on control + tab event\r\n   */\r\n  @HostListener('document:keydown.control.tab')\r\n  changeTab() {\r\n    this.activeIndex = (this.activeIndex + 1) % this.tabs.length;\r\n    this.triggerTabChangeEvent(this.activeIndex);\r\n  }\r\n\r\n  /**\r\n   * New Tab on Ctrl + N\r\n   */\r\n  newTab(tabEvent: OpenFileEvent) {\r\n    if (!tabEvent.file_name) this.createBlankTab();\r\n    if (!tabEvent.path) this.createBlankTab();\r\n\r\n    let newTab: Tab = {\r\n      ...NEW_TAB_DEFAULT,\r\n      id: this.tabs.length,\r\n      title: tabEvent.file_name,\r\n      path: tabEvent.path,\r\n    };\r\n\r\n    this.tabs.push(newTab);\r\n    this.tabs[this.activeIndex].selected = false;\r\n    this.activeIndex = newTab.id;\r\n    this.triggerTabChangeEvent(this.activeIndex);\r\n  }\r\n\r\n  @HostListener('document:keydown.control.N')\r\n  createBlankTab() {\r\n    let newTab: Tab = { ...NEW_TAB_DEFAULT, id: this.tabs.length };\r\n    this.tabs.push(newTab);\r\n    this.tabs[this.activeIndex].selected = false;\r\n    this.activeIndex = newTab.id;\r\n    this.triggerTabChangeEvent(this.activeIndex);\r\n  }\r\n\r\n  triggerTabChangeEvent(index: number = 0) {\r\n    if (this.tabs?.length)\r\n      this.activeTabChangeEvent.emit({ path: this.tabs[index].path, file: this.tabs[index].title});\r\n  }\r\n}\r\n",
             "styleUrl": "./tabs.component.scss",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
             "extends": [],
             "implements": [
-                "AfterViewInit"
+                "OnInit"
             ],
             "templateData": "<div  class=\"tabs-container\">\r\n  <p-tabView (activeIndexChange)=\"triggerTabChangeEvent($event)\"  [(activeIndex)]=\"activeIndex\" id=\"closableTabView\" [scrollable]=\"true\">\r\n    <p-tabPanel *ngFor=\"let tab of tabs\" [selected]=\"tab.selected\" [closable]=\"tab.isClosable\">\r\n        <!-- HEADER -->\r\n        <ng-template  pTemplate=\"header\">\r\n            <div  class=\"flex align-items-center gap-2\">\r\n                    {{tab.title}}\r\n            </div>\r\n        </ng-template>\r\n        <!-- Content  -->\r\n    </p-tabPanel>\r\n  </p-tabView>\r\n</div>\r\n"
         },
@@ -1676,7 +1898,7 @@
         },
         {
             "name": "WorkpadComponent",
-            "id": "component-WorkpadComponent-e770a6bd5ae8393da2b453f48fdc588cf1b74bafd7e272649fbcea8a31de55d420c5f7de21c46f7d273ea31cedb637ba33f58e49435ddbfbb05bf6070c186011",
+            "id": "component-WorkpadComponent-be4424f352ad031e6ded270d5db31c0d30805ae18b3f3fc753a9edc6083145fcd70d8e402a07187b6bf9576d1124f9e6c98c1205ecc12d9505ad60828123fc4f",
             "file": "src/app/modules/ui-elements/workpad/workpad.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1698,13 +1920,35 @@
                     "deprecationMessage": "",
                     "rawdescription": "\n\nTakes input string from tabs . Which reads data from the file\n",
                     "description": "<p>Takes input string from tabs . Which reads data from the file</p>\n",
-                    "line": 23,
-                    "type": "String | undefined",
+                    "line": 27,
+                    "type": "string",
                     "decorators": []
                 }
             ],
-            "outputsClass": [],
+            "outputsClass": [
+                {
+                    "name": "saveFileEvent",
+                    "defaultValue": "new EventEmitter<SaveFileEvent>()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 29,
+                    "type": "EventEmitter"
+                }
+            ],
             "propertiesClass": [
+                {
+                    "name": "quill",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Quill",
+                    "optional": false,
+                    "description": "<p>Quill Editor object to access the internal apis</p>\n",
+                    "line": 36,
+                    "rawdescription": "\n\nQuill Editor object to access the internal apis\n",
+                    "modifierKind": [
+                        123
+                    ]
+                },
                 {
                     "name": "showHeader",
                     "defaultValue": "false",
@@ -1712,22 +1956,85 @@
                     "deprecationMessage": "",
                     "type": "boolean",
                     "optional": false,
-                    "description": "",
-                    "line": 30
+                    "description": "<p>Toggle to enable/disable header toolbar</p>\n",
+                    "line": 41,
+                    "rawdescription": "\n\nToggle to enable/disable header toolbar\n"
                 },
                 {
-                    "name": "work",
-                    "defaultValue": "''",
+                    "name": "supportsQuill",
+                    "defaultValue": "false",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "type": "String",
+                    "type": "boolean",
                     "optional": false,
-                    "description": "<p>Current draft work in progress</p>\n",
-                    "line": 28,
-                    "rawdescription": "\n\nCurrent draft work in progress\n"
+                    "description": "",
+                    "line": 31
                 }
             ],
             "methodsClass": [
+                {
+                    "name": "getCurrentDraf",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 82,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "rawdescription": "\n\nTo emit the current content to the rusty-view to save.\n",
+                    "description": "<p>To emit the current content to the rusty-view to save.</p>\n",
+                    "decorators": [
+                        {
+                            "name": "HostListener",
+                            "stringifiedArguments": "'document:keydown.control.S'"
+                        }
+                    ],
+                    "modifierKind": [
+                        170
+                    ]
+                },
+                {
+                    "name": "initializeEditor",
+                    "args": [
+                        {
+                            "name": "event",
+                            "type": "EditorInitEvent",
+                            "deprecated": false,
+                            "deprecationMessage": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 50,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "rawdescription": "\n\nTriggered when the Quill Editor is initialiezed\n",
+                    "description": "<p>Triggered when the Quill Editor is initialiezed</p>\n",
+                    "jsdoctags": [
+                        {
+                            "name": "event",
+                            "type": "EditorInitEvent",
+                            "deprecated": false,
+                            "deprecationMessage": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "loadDataFromFile",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 58,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "rawdescription": "\n\nLoads the data in the workpad form file\n",
+                    "description": "<p>Loads the data in the workpad form file</p>\n"
+                },
                 {
                     "name": "ngOnChanges",
                     "args": [
@@ -1741,7 +2048,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 35,
+                    "line": 43,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "jsdoctags": [
@@ -1755,35 +2062,6 @@
                             }
                         }
                     ]
-                },
-                {
-                    "name": "ngOnInit",
-                    "args": [],
-                    "optional": false,
-                    "returnType": "void",
-                    "typeParameters": [],
-                    "line": 32,
-                    "deprecated": false,
-                    "deprecationMessage": ""
-                },
-                {
-                    "name": "printCurrentValue",
-                    "args": [],
-                    "optional": false,
-                    "returnType": "void",
-                    "typeParameters": [],
-                    "line": 40,
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "decorators": [
-                        {
-                            "name": "HostListener",
-                            "stringifiedArguments": "'document:keydown.control.P'"
-                        }
-                    ],
-                    "modifierKind": [
-                        170
-                    ]
                 }
             ],
             "deprecated": false,
@@ -1791,12 +2069,14 @@
             "hostBindings": [],
             "hostListeners": [
                 {
-                    "name": "document:keydown.control.P",
+                    "name": "document:keydown.control.S",
                     "args": [],
                     "argsDecorator": [],
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 40
+                    "rawdescription": "\n\nTo emit the current content to the rusty-view to save.\n",
+                    "description": "<p>To emit the current content to the rusty-view to save.</p>\n",
+                    "line": 82
                 }
             ],
             "standalone": true,
@@ -1812,22 +2092,24 @@
                 {
                     "name": "FormsModule",
                     "type": "module"
+                },
+                {
+                    "name": "NgStyle"
                 }
             ],
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import {\r\n  Component,\r\n  HostListener,\r\n  Input,\r\n  OnChanges,\r\n  OnInit,\r\n  SimpleChanges,\r\n} from '@angular/core';\r\nimport { CommonModule } from '@angular/common';\r\nimport { EditorModule } from 'primeng/editor';\r\nimport { FormsModule } from '@angular/forms';\r\n@Component({\r\n  selector: 'app-workpad',\r\n  standalone: true,\r\n  imports: [CommonModule, EditorModule, FormsModule],\r\n  templateUrl: './workpad.component.html',\r\n  styleUrl: './workpad.component.scss',\r\n})\r\nexport class WorkpadComponent implements OnInit, OnChanges {\r\n  /**\r\n   * Takes input string from tabs . Which reads data from the file\r\n   */\r\n  @Input('contentFromFile') contentFromFile: String | undefined;\r\n\r\n  /**\r\n   * Current draft work in progress\r\n   */\r\n  work: String = '';\r\n\r\n  showHeader: boolean = false;\r\n\r\n  ngOnInit(): void {\r\n    if (this.contentFromFile) this.work = this.contentFromFile;\r\n  }\r\n  ngOnChanges(changes: SimpleChanges): void {\r\n    this.work = changes['contentFromFile'].currentValue;\r\n  }\r\n\r\n  @HostListener('document:keydown.control.P')\r\n  printCurrentValue() {\r\n    console.log('Current value is ', this.work);\r\n  }\r\n}\r\n",
+            "sourceCode": "import {\r\n  Component,\r\n  EventEmitter,\r\n  HostListener,\r\n  Input,\r\n  OnChanges,\r\n  Output,\r\n  SimpleChanges,\r\n} from '@angular/core';\r\nimport { CommonModule, NgStyle } from '@angular/common';\r\nimport { EditorInitEvent, EditorModule } from 'primeng/editor';\r\nimport { FormsModule } from '@angular/forms';\r\nimport Quill from 'quill';\r\nimport { SaveFileEvent } from '../../utilities/interfaces/Events';\r\nimport { Delta } from 'quill/core';\r\n@Component({\r\n  selector: 'app-workpad',\r\n  standalone: true,\r\n  imports: [CommonModule, EditorModule, FormsModule, NgStyle],\r\n  templateUrl: './workpad.component.html',\r\n  styleUrl: './workpad.component.scss',\r\n})\r\nexport class WorkpadComponent implements OnChanges {\r\n  /**\r\n   * Takes input string from tabs . Which reads data from the file\r\n   */\r\n  @Input('contentFromFile') contentFromFile!: string;\r\n\r\n  @Output() saveFileEvent = new EventEmitter<SaveFileEvent>();\r\n\r\n  supportsQuill: boolean = false;\r\n\r\n  /**\r\n   * Quill Editor object to access the internal apis\r\n   */\r\n  private quill!: Quill;\r\n\r\n  /**\r\n   * Toggle to enable/disable header toolbar\r\n   */\r\n  showHeader: boolean = false;\r\n\r\n  ngOnChanges(changes: SimpleChanges): void {\r\n    this.loadDataFromFile();\r\n  }\r\n\r\n  /**\r\n   * Triggered when the Quill Editor is initialiezed\r\n   */\r\n  initializeEditor(event: EditorInitEvent) {\r\n    this.quill = event.editor;\r\n    this.loadDataFromFile();\r\n  }\r\n\r\n  /**\r\n   * Loads the data in the workpad form file\r\n   */\r\n  loadDataFromFile() {\r\n    if (this.quill) {\r\n      let delta;\r\n      try {\r\n        delta = new Delta(JSON.parse(this.contentFromFile));\r\n        console.log(\"delta is \", delta, this.contentFromFile);\r\n        \r\n        if( !delta.ops.length ) {\r\n          throw new Error(\"Not a Quill Object \");\r\n        }\r\n        \r\n        this.supportsQuill = true;\r\n        this.quill.setContents(delta);\r\n      } catch (error) {\r\n        this.quill.setText(this.contentFromFile);\r\n        this.supportsQuill = false;\r\n      }\r\n    }\r\n  }\r\n\r\n  /**\r\n   * To emit the current content to the rusty-view to save.\r\n   */\r\n  @HostListener('document:keydown.control.S')\r\n  getCurrentDraf() {\r\n    if (this.quill) {\r\n      if (this.supportsQuill)\r\n        return this.saveFileEvent.emit({ data: JSON.stringify(this.quill.getContents()) });\r\n      else {\r\n        return this.saveFileEvent.emit({ data: this.quill.getText() });\r\n      }\r\n    }\r\n    return this.saveFileEvent.emit({ data: undefined });\r\n  }\r\n\r\n}\r\n",
             "styleUrl": "./workpad.component.scss",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
             "extends": [],
             "implements": [
-                "OnInit",
                 "OnChanges"
             ],
-            "templateData": "<p-editor [(ngModel)]=\"work\" class=\"workpad\">\r\n    <ng-template  pTemplate=\"header\">\r\n        <span *ngIf=\"showHeader\" class=\"ql-formats\">\r\n            <button type=\"button\" class=\"ql-bold\" aria-label=\"Bold\"></button>\r\n            <button type=\"button\" class=\"ql-italic\" aria-label=\"Italic\"></button>\r\n            <button type=\"button\" class=\"ql-underline\" aria-label=\"Underline\"></button>\r\n        </span>\r\n    </ng-template>\r\n</p-editor>"
+            "templateData": "<p-editor (onInit)=\"initializeEditor($event)\" [spellcheck]=\"false\" class=\"workpad\">\r\n    <ng-template  pTemplate=\"header\">\r\n        <span *ngIf=\"showHeader\" class=\"ql-formats\">\r\n            <button type=\"button\" class=\"ql-bold\" aria-label=\"Bold\"></button>\r\n            <button type=\"button\" class=\"ql-italic\" aria-label=\"Italic\"></button>\r\n            <button type=\"button\" class=\"ql-underline\" aria-label=\"Underline\"></button>\r\n        </span>\r\n    </ng-template>\r\n</p-editor>"
         }
     ],
     "modules": [
@@ -1929,6 +2211,26 @@
                 "defaultValue": "{\r\n  name: \"notes\",\r\n  nodes: [],\r\n  isDirectory: false,\r\n  expanded: false,\r\n  path: \".\"\r\n}"
             },
             {
+                "name": "environment",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/environments/environment.development.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "object",
+                "defaultValue": "{\r\n  prodcution: true,\r\n  current_directory: \"D:\\\\rusty-workspace\\\\\"\r\n}"
+            },
+            {
+                "name": "environment",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/environments/environment.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "object",
+                "defaultValue": "{\r\n  prodcution: true,\r\n  current_directory: \".\\\\\"\r\n}"
+            },
+            {
                 "name": "NEW_TAB_DEFAULT",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -1936,7 +2238,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Tab",
-                "defaultValue": "{\r\nid: -1,\r\nisClosable: true,\r\nselected: true,\r\ntitle: \"New Tab\",\r\npath: \".\"\r\n}"
+                "defaultValue": "{\r\nid: -1,\r\nisClosable: true,\r\nselected: true,\r\ntitle: \"New Tab\",\r\npath: undefined\r\n}"
             }
         ],
         "functions": [
@@ -2046,6 +2348,30 @@
                     "defaultValue": "{\r\n  name: \"notes\",\r\n  nodes: [],\r\n  isDirectory: false,\r\n  expanded: false,\r\n  path: \".\"\r\n}"
                 }
             ],
+            "src/environments/environment.development.ts": [
+                {
+                    "name": "environment",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/environments/environment.development.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "object",
+                    "defaultValue": "{\r\n  prodcution: true,\r\n  current_directory: \"D:\\\\rusty-workspace\\\\\"\r\n}"
+                }
+            ],
+            "src/environments/environment.ts": [
+                {
+                    "name": "environment",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/environments/environment.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "object",
+                    "defaultValue": "{\r\n  prodcution: true,\r\n  current_directory: \".\\\\\"\r\n}"
+                }
+            ],
             "src/app/modules/utilities/Constants.ts": [
                 {
                     "name": "NEW_TAB_DEFAULT",
@@ -2055,7 +2381,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Tab",
-                    "defaultValue": "{\r\nid: -1,\r\nisClosable: true,\r\nselected: true,\r\ntitle: \"New Tab\",\r\npath: \".\"\r\n}"
+                    "defaultValue": "{\r\nid: -1,\r\nisClosable: true,\r\nselected: true,\r\ntitle: \"New Tab\",\r\npath: undefined\r\n}"
                 }
             ]
         },
@@ -2158,7 +2484,7 @@
     },
     "routes": [],
     "coverage": {
-        "count": 3,
+        "count": 4,
         "status": "low",
         "files": [
             {
@@ -2203,7 +2529,7 @@
                 "linktype": "component",
                 "name": "FolderTreeComponent",
                 "coveragePercent": 0,
-                "coverageCount": "0/10",
+                "coverageCount": "0/11",
                 "status": "low"
             },
             {
@@ -2221,7 +2547,7 @@
                 "linktype": "component",
                 "name": "FolderComponent",
                 "coveragePercent": 0,
-                "coverageCount": "0/4",
+                "coverageCount": "0/6",
                 "status": "low"
             },
             {
@@ -2238,8 +2564,8 @@
                 "type": "injectable",
                 "linktype": "injectable",
                 "name": "ViewService",
-                "coveragePercent": 0,
-                "coverageCount": "0/5",
+                "coveragePercent": 20,
+                "coverageCount": "1/5",
                 "status": "low"
             },
             {
@@ -2248,7 +2574,7 @@
                 "linktype": "component",
                 "name": "RustyViewComponent",
                 "coveragePercent": 0,
-                "coverageCount": "0/5",
+                "coverageCount": "0/9",
                 "status": "low"
             },
             {
@@ -2283,9 +2609,9 @@
                 "type": "component",
                 "linktype": "component",
                 "name": "WorkpadComponent",
-                "coveragePercent": 25,
-                "coverageCount": "2/8",
-                "status": "low"
+                "coveragePercent": 63,
+                "coverageCount": "7/11",
+                "status": "good"
             },
             {
                 "filePath": "src/app/modules/utilities/Constants.ts",
@@ -2302,6 +2628,24 @@
                 "type": "interface",
                 "linktype": "interface",
                 "name": "OpenFileEvent",
+                "coveragePercent": 0,
+                "coverageCount": "0/3",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/modules/utilities/interfaces/Events.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "SaveFileEvent",
+                "coveragePercent": 0,
+                "coverageCount": "0/3",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/modules/utilities/interfaces/Events.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "TabChangeEvent",
                 "coveragePercent": 0,
                 "coverageCount": "0/3",
                 "status": "low"
@@ -2370,6 +2714,26 @@
                 "name": "Tab",
                 "coveragePercent": 0,
                 "coverageCount": "0/6",
+                "status": "low"
+            },
+            {
+                "filePath": "src/environments/environment.development.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "environment",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/environments/environment.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "environment",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
                 "status": "low"
             }
         ]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --configuration=development",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "tauri": "tauri",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-cloudpickle==3.0.0
-doit==0.36.0
-importlib_metadata==8.0.0
-zipp==3.19.2
+{"ops":[{"insert":"cloudpickle==3.0.0\ndoit==0.36.0\nimportlib_metadata==8.0.0\nzipp==3.19.2\n\nthis point 1"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"this is point 2"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"this is point 3 "},{"attributes":{"list":"ordered"},"insert":"\n\n"}]}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1632,6 +1632,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2176,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rfd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.37.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2686,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
+ "rfd",
  "semver",
  "serde",
  "serde_json",
@@ -3210,6 +3246,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3285,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webkit2gtk"
@@ -3353,6 +3411,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
 
 [[package]]
 name = "windows"
@@ -3511,6 +3582,12 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -3532,6 +3609,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3565,6 +3648,12 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -3586,6 +3675,12 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3628,6 +3723,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1", features = [] }
 
 [dependencies]
-tauri = { version = "1", features = [ "dialog-save", "shell-open"] }
+tauri = { version = "1", features = [ "path-all", "dialog-save", "shell-open"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1", features = [] }
 
 [dependencies]
-tauri = { version = "1", features = ["shell-open"] }
+tauri = { version = "1", features = [ "dialog-save", "shell-open"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/src/file_explorer.rs
+++ b/src-tauri/src/file_explorer.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    ffi::OsStr, fs::{self, File}, io::{self, Read, Write}, path::PathBuf
+    fs::{self, File}, io::{self, Read, Write}, path::PathBuf
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -23,6 +23,8 @@ pub fn _list_files(vec: &mut Vec<SystemObject>, path: &PathBuf) -> io::Result<()
             vec.push(node);
         }
 
+        /* This is the root directory which is used to display the current opened directory in the notepad */
+        
         vec.push(SystemObject {
             file_name: path
                 .file_name()
@@ -44,8 +46,8 @@ pub fn _read_file(path: String) -> String {
     return content;
 }
 
-pub fn save_file(path: String, data: String) -> std::io::Result<()> {
+pub fn save_file(path: &String, data: String) -> std::io::Result<()> {
     print!("Saving current file on path  {path} and {data}");
-    let mut file = fs::OpenOptions::new().write(true).open(path).unwrap();
+    let mut file = fs::OpenOptions::new().create_new(true).write(true).open(path).unwrap();
     file.write_all(data.as_bytes())
 }

--- a/src-tauri/src/file_explorer.rs
+++ b/src-tauri/src/file_explorer.rs
@@ -1,24 +1,24 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::{self, File},
-    io::{self, Read, Write},
-    path::PathBuf,
+    ffi::OsStr, fs::{self, File}, io::{self, Read, Write}, path::PathBuf
 };
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SystemObject {
-    file_name: String,
-    is_folder: bool,
+    pub file_name: String,
+    pub is_folder: bool,
+    pub err: Option<String>
 }
 
-pub fn _list_files(vec: &mut Vec<SystemObject>, path: PathBuf) -> io::Result<()> {
+pub fn _list_files(vec: &mut Vec<SystemObject>, path: &PathBuf) -> io::Result<()> {
     if path.is_dir() {
-        let paths = fs::read_dir(&path)?;
+        let paths = fs::read_dir(path)?;
         for path_result in paths {
             let entry = &path_result?;
             let node = SystemObject {
                 file_name: String::from(entry.file_name().into_string().unwrap()),
                 is_folder: entry.file_type()?.is_dir(),
+                err: None
             };
             vec.push(node);
         }
@@ -31,6 +31,7 @@ pub fn _list_files(vec: &mut Vec<SystemObject>, path: PathBuf) -> io::Result<()>
                 .unwrap_or(&String::from("workpad"))
                 .to_string(),
             is_folder: path.is_dir(),
+            err: None
         });
     }
     Ok(())

--- a/src-tauri/src/file_explorer.rs
+++ b/src-tauri/src/file_explorer.rs
@@ -1,13 +1,15 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::{self, File}, io::{self, Read, Write}, path::PathBuf
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::PathBuf,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SystemObject {
     pub file_name: String,
     pub is_folder: bool,
-    pub err: Option<String>
+    pub err: Option<String>,
 }
 
 pub fn _list_files(vec: &mut Vec<SystemObject>, path: &PathBuf) -> io::Result<()> {
@@ -18,13 +20,13 @@ pub fn _list_files(vec: &mut Vec<SystemObject>, path: &PathBuf) -> io::Result<()
             let node = SystemObject {
                 file_name: String::from(entry.file_name().into_string().unwrap()),
                 is_folder: entry.file_type()?.is_dir(),
-                err: None
+                err: None,
             };
             vec.push(node);
         }
 
         /* This is the root directory which is used to display the current opened directory in the notepad */
-        
+
         vec.push(SystemObject {
             file_name: path
                 .file_name()
@@ -33,7 +35,7 @@ pub fn _list_files(vec: &mut Vec<SystemObject>, path: &PathBuf) -> io::Result<()
                 .unwrap_or(&String::from("workpad"))
                 .to_string(),
             is_folder: path.is_dir(),
-            err: None
+            err: None,
         });
     }
     Ok(())
@@ -47,7 +49,24 @@ pub fn _read_file(path: String) -> String {
 }
 
 pub fn save_file(path: &String, data: String) -> std::io::Result<()> {
-    print!("Saving current file on path  {path} and {data}");
-    let mut file = fs::OpenOptions::new().create_new(true).write(true).open(path).unwrap();
+  let mut file;
+  if check_file_existance(path) {
+        println!("Updating current file ");
+        file = fs::OpenOptions::new().write(true).open(path).unwrap();
+    } else {
+      println!("Creating a new file and writing contents in it ");
+        file = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+    }
     file.write_all(data.as_bytes())
+}
+
+fn check_file_existance(path: &String) -> bool {
+    match fs::metadata(path) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
 }

--- a/src-tauri/src/file_explorer.rs
+++ b/src-tauri/src/file_explorer.rs
@@ -49,24 +49,13 @@ pub fn _read_file(path: String) -> String {
 }
 
 pub fn save_file(path: &String, data: String) -> std::io::Result<()> {
-  let mut file;
-  if check_file_existance(path) {
-        println!("Updating current file ");
-        file = fs::OpenOptions::new().write(true).open(path).unwrap();
-    } else {
-      println!("Creating a new file and writing contents in it ");
-        file = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(path)
-            .unwrap();
-    }
-    file.write_all(data.as_bytes())
-}
 
-fn check_file_existance(path: &String) -> bool {
-    match fs::metadata(path) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+  let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+    file.write_all(data.as_bytes())?;
+    file.flush()?;
+    Ok(())
 }

--- a/src-tauri/src/file_explorer.rs
+++ b/src-tauri/src/file_explorer.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::{self},
-    io::{self, Read},
+    fs::{self, File},
+    io::{self, Read, Write},
     path::PathBuf,
 };
 
@@ -37,8 +37,14 @@ pub fn _list_files(vec: &mut Vec<SystemObject>, path: PathBuf) -> io::Result<()>
 }
 
 pub fn _read_file(path: String) -> String {
-    let mut in_file = std::fs::File::open(path).unwrap();
+    let mut in_file = File::open(path).unwrap();
     let mut content = String::new();
-    in_file.read_to_string(&mut content);
+    let _ = in_file.read_to_string(&mut content);
     return content;
+}
+
+pub fn save_file(path: String, data: String) -> std::io::Result<()> {
+    print!("Saving current file on path  {path} and {data}");
+    let mut file = fs::OpenOptions::new().write(true).open(path).unwrap();
+    file.write_all(data.as_bytes())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,10 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{env, path::{self, PathBuf}};
+use std::{
+    env,
+    path::PathBuf,
+};
 
 use file_explorer::SystemObject;
 pub mod file_explorer;
@@ -10,16 +13,15 @@ pub mod file_explorer;
 #[tauri::command]
 async fn read_directory(path: String) -> Vec<SystemObject> {
     let mut vec = Vec::new();
-    let mut asb_path: PathBuf;
+    let asb_path: PathBuf;
 
-    if (path.starts_with(".")) {
-      asb_path = match env::current_dir() {
-        Ok((p)) => p,
-        Err((err)) => PathBuf::from("undefined")
-      }
-    }
-    else{
-      asb_path = PathBuf::from(path);
+    if path.starts_with(".") {
+        asb_path = match env::current_dir() {
+            Ok(p) => p,
+            Err(_err) => PathBuf::from("undefined"),
+        }
+    } else {
+        asb_path = PathBuf::from(path);
     }
 
     let _ = file_explorer::_list_files(&mut vec, &asb_path);
@@ -27,23 +29,27 @@ async fn read_directory(path: String) -> Vec<SystemObject> {
 }
 
 #[tauri::command]
-async fn read_file(path:String) -> String {
+async fn read_file(path: String) -> String {
     file_explorer::_read_file(path)
 }
 
 #[tauri::command]
-async fn save_file(path:String, data:String) -> String {
-  let save_file_result = file_explorer::save_file(path, data);
-  let res = match save_file_result {
-      Ok(()) => String::from("Saved File successfully"),
-      Err(e) => e.to_string(),
-  };
-  return res;
+async fn save_file(path: String, data: String) -> String {
+    let save_file_result = file_explorer::save_file(&path, data);
+    let res = match save_file_result {
+        Ok(()) => String::from("Saved File successfully"),
+        Err(e) => e.to_string(),
+    };
+    return res;
 }
 
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![read_directory, read_file, save_file])
+        .invoke_handler(tauri::generate_handler![
+            read_directory,
+            read_file,
+            save_file
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,17 +1,28 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::path::PathBuf;
+use std::{env, path::{self, PathBuf}};
 
 use file_explorer::SystemObject;
 pub mod file_explorer;
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
-async fn read_directory(path: String) -> Vec<SystemObject>{
+async fn read_directory(path: String) -> Vec<SystemObject> {
     let mut vec = Vec::new();
-    let path = PathBuf::from(String::from(path));
-    let _ = file_explorer::_list_files(&mut vec, path);
+    let mut asb_path: PathBuf;
+
+    if (path.starts_with(".")) {
+      asb_path = match env::current_dir() {
+        Ok((p)) => p,
+        Err((err)) => PathBuf::from("undefined")
+      }
+    }
+    else{
+      asb_path = PathBuf::from(path);
+    }
+
+    let _ = file_explorer::_list_files(&mut vec, &asb_path);
     vec
 }
 
@@ -24,7 +35,7 @@ async fn read_file(path:String) -> String {
 async fn save_file(path:String, data:String) -> String {
   let save_file_result = file_explorer::save_file(path, data);
   let res = match save_file_result {
-      Ok(file) => String::from("Saved File successfully"),
+      Ok(()) => String::from("Saved File successfully"),
       Err(e) => e.to_string(),
   };
   return res;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,10 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{
-    env,
-    path::PathBuf,
-};
+use std::{env, path::PathBuf};
 
 use file_explorer::SystemObject;
 pub mod file_explorer;
@@ -36,11 +33,10 @@ async fn read_file(path: String) -> String {
 #[tauri::command]
 async fn save_file(path: String, data: String) -> String {
     let save_file_result = file_explorer::save_file(&path, data);
-    let res = match save_file_result {
+    match save_file_result {
         Ok(()) => String::from("Saved File successfully"),
-        Err(e) => e.to_string(),
-    };
-    return res;
+        Err(e) => String::from(e.to_string()),
+    }
 }
 
 fn main() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ pub mod file_explorer;
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
-fn read_directory(path: String) -> Vec<SystemObject>{
+async fn read_directory(path: String) -> Vec<SystemObject>{
     let mut vec = Vec::new();
     let path = PathBuf::from(String::from(path));
     let _ = file_explorer::_list_files(&mut vec, path);
@@ -16,13 +16,23 @@ fn read_directory(path: String) -> Vec<SystemObject>{
 }
 
 #[tauri::command]
-fn read_file(path_str:String) -> String {
-    file_explorer::_read_file(path_str)
+async fn read_file(path:String) -> String {
+    file_explorer::_read_file(path)
+}
+
+#[tauri::command]
+async fn save_file(path:String, data:String) -> String {
+  let save_file_result = file_explorer::save_file(path, data);
+  let res = match save_file_result {
+      Ok(file) => String::from("Saved File successfully"),
+      Err(e) => e.to_string(),
+  };
+  return res;
 }
 
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![read_directory, read_file])
+        .invoke_handler(tauri::generate_handler![read_directory, read_file, save_file])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,14 @@
   },
   "tauri": {
     "allowlist": {
+      "dialog": {
+        "all": false,
+        "ask": false,
+        "confirm": false,
+        "message": false,
+        "open": false,
+        "save": true
+      },
       "all": false,
       "shell": {
         "all": false,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,9 @@
   },
   "tauri": {
     "allowlist": {
+      "path": {
+        "all": true
+      },
       "dialog": {
         "all": false,
         "ask": false,

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.html
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.html
@@ -16,7 +16,7 @@
           {{ fileSystemItem.name }}
         </span>
         <ul *ngIf="fileSystemItem.expanded" style="padding-left: .7rem;">
-          <rusty-folder *ngIf="fileSystemItem.nodes" [folders]="fileSystemItem.nodes" />
+          <rusty-folder (openFileEvent)="handleNestedFileOpenEvent($event)" *ngIf="fileSystemItem.nodes" [folders]="fileSystemItem.nodes" />
         </ul>
       </li>
     </ul>

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.html
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.html
@@ -1,24 +1,15 @@
-<ul class="my-0" style="padding: 2px 0px 0px 3px;">
+<ul class="my-0" style="padding: 2px 0px 0px 3px">
   <li class="py-1">
-    <span (click)="root.expanded = !root.expanded" class="flex items-center item" style="font-weight: 500;">
-      <i  style="font-size: 12px; align-content: end; margin-right: 3px;" class="pi"
+    <!-- Root Folder  -->
+    <span (click)="root.expanded = !root.expanded" class="flex items-center item" style="font-weight: 500">
+      <i style="font-size: 12px; align-content: end; margin-right: 3px" class="pi"
         [ngClass]="root.expanded ? 'pi-angle-down' : 'pi-angle-right'"></i>
-      {{ root.name | uppercase}}
+      {{ root.name | uppercase }}
     </span>
 
-    <ul *ngIf="root.expanded" style="padding-left: .7rem;">
-      <li class="py-1 item" *ngFor="let fileSystemItem of workspace; index as i">
-        <span (click)="this.handleFileSystemClick(i)" class="flex items-center "
-          [ngClass]="fileSystemItem.isDirectory ? '' : 'ml-2'">
-          <i style="font-size: 12px; align-content: end; margin-right: 3px;" *ngIf="fileSystemItem.isDirectory" class="pi" [ngClass]="
-              fileSystemItem.expanded ? 'pi-angle-down' : 'pi-angle-right'
-            "></i>
-          {{ fileSystemItem.name }}
-        </span>
-        <ul *ngIf="fileSystemItem.expanded" style="padding-left: .7rem;">
-          <rusty-folder (openFileEvent)="handleNestedFileOpenEvent($event)" *ngIf="fileSystemItem.nodes" [folders]="fileSystemItem.nodes" />
-        </ul>
-      </li>
+    <!-- Contents of the Opened Directory -->
+    <ul *ngIf="root.expanded" style="padding-left: 0.7rem">
+      <rusty-folder (openFileEvent)="this.handleFileSystemClick($event)" *ngIf="workspace.length" [folders]="workspace" />
     </ul>
   </li>
 </ul>

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.html
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.html
@@ -1,5 +1,5 @@
 <ul class="my-0" style="padding: 2px 0px 0px 3px;">
-  <li class="my-1">
+  <li class="py-1">
     <span (click)="root.expanded = !root.expanded" class="flex items-center item" style="font-weight: 500;">
       <i  style="font-size: 12px; align-content: end; margin-right: 3px;" class="pi"
         [ngClass]="root.expanded ? 'pi-angle-down' : 'pi-angle-right'"></i>
@@ -7,8 +7,8 @@
     </span>
 
     <ul *ngIf="root.expanded" style="padding-left: .7rem;">
-      <li class="my-1" *ngFor="let fileSystemItem of workspace; index as i">
-        <span (click)="this.handleFileSystemClick(i)" class="flex items-center item"
+      <li class="py-1 item" *ngFor="let fileSystemItem of workspace; index as i">
+        <span (click)="this.handleFileSystemClick(i)" class="flex items-center "
           [ngClass]="fileSystemItem.isDirectory ? '' : 'ml-2'">
           <i style="font-size: 12px; align-content: end; margin-right: 3px;" *ngIf="fileSystemItem.isDirectory" class="pi" [ngClass]="
               fileSystemItem.expanded ? 'pi-angle-down' : 'pi-angle-right'

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.scss
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.scss
@@ -4,7 +4,7 @@
 }
 .item:hover {
   background-color: var(--bluegray-900);
-  border-radius: 2px;
+  border: 1px solid var(--accent-color);
   cursor: pointer;
 }
 ul {

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.scss
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.scss
@@ -2,7 +2,7 @@
   font-size: var(--font-size-secondary);
   font-weight: var(--font-weight-secondary);
 }
-.item:hover {
+.item:hover:not(:has(.item:hover)) {
   background-color: var(--bluegray-900);
   border: 1px solid var(--accent-color);
   cursor: pointer;

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.ts
@@ -4,7 +4,8 @@ import { FolderComponent } from './folder/folder.component';
 import { FolderTreeService } from './folder-tree.service';
 import { Subscription } from 'rxjs';
 import { Node } from '../../utilities/interfaces/Node';
-import { OpenFileEvent } from '../../utilities/interfaces/Events';
+import { FileEvents, FileEventType } from '../../utilities/interfaces/Events';
+import { ViewService } from '../rusty-view/rusty-vew.service';
 
 @Component({
   selector: 'rusty-folder-tree',
@@ -15,14 +16,14 @@ import { OpenFileEvent } from '../../utilities/interfaces/Events';
 })
 export class FolderTreeComponent implements OnDestroy {
 
-  @Output() openFileEvent = new EventEmitter<OpenFileEvent>();
+  @Output() openFileEvent = new EventEmitter<FileEvents>();
   workspace!: Node[];
   workspace$!: Subscription;
 
   root!: Node;
   root$!: Subscription;
 
-  constructor(public fsService: FolderTreeService) {
+  constructor(public fsService: FolderTreeService, private rustyViewService: ViewService) {
     this.workspace$ = this.fsService.workspace.subscribe((ele: Node[]) => {
       this.workspace = ele;
     });
@@ -37,19 +38,8 @@ export class FolderTreeComponent implements OnDestroy {
     this.root$.unsubscribe();
   }
 
-  handleFileSystemClick(index: number) {
-    if (this.workspace[index].isDirectory)
-      this.fsService.openDirectory(this.workspace, index);
-    else
-      this.openFileEvent.emit({
-        file_name: this.workspace[index].name,
-        path: this.workspace[index].path,
-      });
+  handleFileSystemClick(fileEvent: FileEvents) {
+    this.openFileEvent.emit(fileEvent);
   }
 
-  handleNestedFileOpenEvent(event: OpenFileEvent) {
-    console.log("this got called ", event);
-    
-    this.openFileEvent.emit(event);
-  }
 }

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.component.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.component.ts
@@ -14,6 +14,7 @@ import { OpenFileEvent } from '../../utilities/interfaces/Events';
   styleUrl: './folder-tree.component.scss',
 })
 export class FolderTreeComponent implements OnDestroy {
+
   @Output() openFileEvent = new EventEmitter<OpenFileEvent>();
   workspace!: Node[];
   workspace$!: Subscription;
@@ -44,5 +45,11 @@ export class FolderTreeComponent implements OnDestroy {
         file_name: this.workspace[index].name,
         path: this.workspace[index].path,
       });
+  }
+
+  handleNestedFileOpenEvent(event: OpenFileEvent) {
+    console.log("this got called ", event);
+    
+    this.openFileEvent.emit(event);
   }
 }

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.service.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.service.ts
@@ -10,7 +10,7 @@ export class FolderTreeService {
 
   workspace = new BehaviorSubject<Node[]>([]);
   rootNode = new BehaviorSubject<Node>(DEFAULT_NODE);
-  ROOT_NAME:string = '';
+  ROOT_NAME: string = '';
   private BASE_PATH: string = environment.current_directory
 
   constructor() { }
@@ -27,13 +27,13 @@ export class FolderTreeService {
     });
   }
 
-  openDirectory(workspace:Node[], index:number) {
-    if(!workspace[index].isDirectory)
+  openDirectory(workspace: Node[], index: number) {
+    if (!workspace[index].isDirectory)
       return;
 
-    if(!workspace[index].expanded && !workspace[index].nodes?.length)
+    if (!workspace[index].expanded && !workspace[index].nodes?.length)
       this.expandDirectory(workspace[index]);
-    workspace[index].expanded = ! workspace[index].expanded
+    workspace[index].expanded = !workspace[index].expanded
 
   }
 
@@ -42,7 +42,7 @@ export class FolderTreeService {
     invoke<FileSystemItem[]>("read_directory", { path }).then((items: FileSystemItem[]) => {
       items.pop();
       folder.expanded = true;
-      folder.nodes = mapFileSystemItem2NodeList(items, folder.path )
+      folder.nodes = mapFileSystemItem2NodeList(items, folder.path)
     })
   }
 

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.service.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { invoke } from '@tauri-apps/api';
 import { DEFAULT_NODE, FileSystemItem, mapFileSystemItem2Node, mapFileSystemItem2NodeList, Node } from '../../utilities/interfaces/Node';
 import { BehaviorSubject } from 'rxjs';
-
+import { environment } from '../../../../environments/environment';
 @Injectable({
   providedIn: 'root'
 })
@@ -11,7 +11,7 @@ export class FolderTreeService {
   workspace = new BehaviorSubject<Node[]>([]);
   rootNode = new BehaviorSubject<Node>(DEFAULT_NODE);
   ROOT_NAME:string = '';
-  private BASE_PATH: string = 'D:\\OpenSourceSoftware\\rusty-notepad'
+  private BASE_PATH: string = environment.current_directory
 
   constructor() { }
 
@@ -22,7 +22,7 @@ export class FolderTreeService {
         let nodes_list = mapFileSystemItem2NodeList(directory_items, this.BASE_PATH);
         this.rootNode.next({ ...mapFileSystemItem2Node(last_node), expanded: true })
         this.workspace.next(nodes_list)
-        this.ROOT_NAME = last_node.file_name;       
+        this.ROOT_NAME = last_node.file_name;
       }
     });
   }
@@ -30,7 +30,7 @@ export class FolderTreeService {
   openDirectory(workspace:Node[], index:number) {
     if(!workspace[index].isDirectory)
       return;
-    
+
     if(!workspace[index].expanded && !workspace[index].nodes?.length)
       this.expandDirectory(workspace[index]);
     workspace[index].expanded = ! workspace[index].expanded
@@ -42,7 +42,7 @@ export class FolderTreeService {
     invoke<FileSystemItem[]>("read_directory", { path }).then((items: FileSystemItem[]) => {
       items.pop();
       folder.expanded = true;
-      folder.nodes = mapFileSystemItem2NodeList(items, folder.path )      
+      folder.nodes = mapFileSystemItem2NodeList(items, folder.path )
     })
   }
 

--- a/src/app/modules/ui-elements/folder-tree/folder-tree.service.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder-tree.service.ts
@@ -27,13 +27,10 @@ export class FolderTreeService {
     });
   }
 
-  openDirectory(workspace: Node[], index: number) {
-    if (!workspace[index].isDirectory)
-      return;
-
-    if (!workspace[index].expanded && !workspace[index].nodes?.length)
-      this.expandDirectory(workspace[index]);
-    workspace[index].expanded = !workspace[index].expanded
+  openDirectory(workspace: Node) {
+    if (!workspace.expanded && !workspace.nodes?.length)
+      this.expandDirectory(workspace);
+    workspace.expanded = !workspace.expanded
 
   }
 

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.html
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.html
@@ -1,5 +1,5 @@
 <li class="py-1 item" *ngFor="let folder of folders;index as i">
-  <span (click)="this.fs.openDirectory(folders,i)" class="flex items-center">
+  <span (click)="this.handleFileSystemClick(folders, i)" class="flex items-center" [ngClass]="folder.isDirectory ? '' : 'ml-1 mt-1'">
     <i style="font-size: 12px; align-content: end; margin-right: 3px;" *ngIf="folder.isDirectory" class="pi" [ngClass]="
     folder.expanded ? 'pi-angle-down' : 'pi-angle-right'
   "></i> {{folder.name}}

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.html
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.html
@@ -1,5 +1,5 @@
-<li class="my-1" *ngFor="let folder of folders;index as i">
-  <span (click)="this.fs.openDirectory(folders,i)" class="flex items-center item">
+<li class="py-1 item" *ngFor="let folder of folders;index as i">
+  <span (click)="this.fs.openDirectory(folders,i)" class="flex items-center">
     <i style="font-size: 12px; align-content: end; margin-right: 3px;" *ngIf="folder.isDirectory" class="pi" [ngClass]="
     folder.expanded ? 'pi-angle-down' : 'pi-angle-right'
   "></i> {{folder.name}}

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.html
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.html
@@ -1,10 +1,14 @@
+<!-- Contents of the Opened Directory -->
 <li class="py-1 item" *ngFor="let folder of folders;index as i">
-  <span (click)="this.handleFileSystemClick(folders, i)" class="flex items-center" [ngClass]="folder.isDirectory ? '' : 'ml-1 mt-1'">
+  <span (click)="folder.isDirectory? this.openDirectory(folder): this.readFile(folder)" class="flex items-center"
+    [ngClass]="folder.isDirectory ? '' : 'ml-1 mt-1'">
     <i style="font-size: 12px; align-content: end; margin-right: 3px;" *ngIf="folder.isDirectory" class="pi" [ngClass]="
     folder.expanded ? 'pi-angle-down' : 'pi-angle-right'
   "></i> {{folder.name}}
   </span>
+
+  <!-- Sub Folders - if any  -->
   <ul style="padding-left: .7rem;">
-    <rusty-folder *ngIf="folder.nodes && folder.expanded" [folders]="folder.nodes" />
+    <rusty-folder (openFileEvent)="this.handleOpenFileEvent($event)" *ngIf="folder.nodes && folder.expanded" [folders]="folder.nodes" />
   </ul>
 </li>

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.scss
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.scss
@@ -5,7 +5,7 @@
 
 .item:hover {
   background-color: var(--bluegray-900);
-  border-radius: 2px;
+  border: 1px solid var(--accent-color);
   cursor: pointer;
 }
 ul {

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.scss
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.scss
@@ -3,7 +3,7 @@
     padding: 0;
 }
 
-.item:hover {
+.item:hover:not(:has(.item:hover)) {
   background-color: var(--bluegray-900);
   border: 1px solid var(--accent-color);
   cursor: pointer;

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.ts
@@ -2,7 +2,7 @@ import { NgClass, NgFor, NgIf } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Node } from '../../../utilities/interfaces/Node';
 import { FolderTreeService } from '../folder-tree.service';
-import { OpenFileEvent } from '../../../utilities/interfaces/Events';
+import { FileEvents, FileEventType, OpenFileEvent } from '../../../utilities/interfaces/Events';
 
 @Component({
   selector: 'rusty-folder',
@@ -18,18 +18,26 @@ export class FolderComponent {
 
   @Input() folders!:Node[];
 
-  @Output() openFileEvent = new EventEmitter<OpenFileEvent>()
+  @Output() openFileEvent = new EventEmitter<FileEvents>()
 
   constructor(public fs:FolderTreeService){
   }
 
-  handleFileSystemClick(folders: Node[], index: number) {
-    if (folders[index].isDirectory)
-      this.fs.openDirectory(folders, index);
-    else
+  readFile(file:Node) {
       this.openFileEvent.emit({
-        file_name: folders[index].name,
-        path: folders[index].path,
-      });
+        file_name: file.name,
+        path: file.path,
+        type: FileEventType.OPEN
+      })
   }
+  handleOpenFileEvent(event:FileEvents){
+
+    this.openFileEvent.emit(event);
+  }
+
+  openDirectory(folders: Node){
+    this.fs.openDirectory(folders);
+  }
+
+
 }

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.ts
@@ -1,7 +1,8 @@
 import { NgClass, NgFor, NgIf } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Node } from '../../../utilities/interfaces/Node';
 import { FolderTreeService } from '../folder-tree.service';
+import { OpenFileEvent } from '../../../utilities/interfaces/Events';
 
 @Component({
   selector: 'rusty-folder',
@@ -17,7 +18,18 @@ export class FolderComponent {
 
   @Input() folders!:Node[];
 
-  constructor(public fs:FolderTreeService){
+  @Output() openFileEvent = new EventEmitter<OpenFileEvent>()
 
+  constructor(public fs:FolderTreeService){
+  }
+
+  handleFileSystemClick(folders: Node[], index: number) {
+    if (folders[index].isDirectory)
+      this.fs.openDirectory(folders, index);
+    else
+      this.openFileEvent.emit({
+        file_name: folders[index].name,
+        path: folders[index].path,
+      });
   }
 }

--- a/src/app/modules/ui-elements/folder-tree/folder/folder.component.ts
+++ b/src/app/modules/ui-elements/folder-tree/folder/folder.component.ts
@@ -2,12 +2,12 @@ import { NgClass, NgFor, NgIf } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Node } from '../../../utilities/interfaces/Node';
 import { FolderTreeService } from '../folder-tree.service';
-import { FileEvents, FileEventType, OpenFileEvent } from '../../../utilities/interfaces/Events';
+import { FileEvents, FileEventType } from '../../../utilities/interfaces/Events';
 
 @Component({
   selector: 'rusty-folder',
   standalone: true,
-  imports: [NgFor,NgIf,NgClass],
+  imports: [NgFor, NgIf, NgClass],
   host: {
     '[style.list-style-type]': "none"
   },
@@ -16,26 +16,26 @@ import { FileEvents, FileEventType, OpenFileEvent } from '../../../utilities/int
 })
 export class FolderComponent {
 
-  @Input() folders!:Node[];
+  @Input() folders!: Node[];
 
   @Output() openFileEvent = new EventEmitter<FileEvents>()
 
-  constructor(public fs:FolderTreeService){
+  constructor(public fs: FolderTreeService) {
   }
 
-  readFile(file:Node) {
-      this.openFileEvent.emit({
-        file_name: file.name,
-        path: file.path,
-        type: FileEventType.OPEN
-      })
+  readFile(file: Node) {
+    this.openFileEvent.emit({
+      file_name: file.name,
+      path: file.path,
+      type: FileEventType.OPEN
+    })
   }
-  handleOpenFileEvent(event:FileEvents){
+  handleOpenFileEvent(event: FileEvents) {
 
     this.openFileEvent.emit(event);
   }
 
-  openDirectory(folders: Node){
+  openDirectory(folders: Node) {
     this.fs.openDirectory(folders);
   }
 

--- a/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
@@ -24,14 +24,14 @@ export class ViewService {
   }
 
   readFile(path: string | undefined ) {
+
+    // If path is undefined the log a debug message and return the default values
+    if( !path ) {
+      console.debug("Error while opening the file. Path undefined", path);
+      return this.workbook$.next('This is some default \n work from an file');
+    }
+
     console.debug("Reading file with path ", path);
-
-    // If path is undefined the return with error log
-    if( !path ) console.error("Error while opening the file. Path undefined", path);
-
-    // Some default values to be retured for current directory path . TODO Needs to verify if this is required or not :(
-    if (path == '.') return this.workbook$.next('This is some default \n work from an file');
-
     /**
      * Reads the content of the file from the given path
      */
@@ -49,7 +49,7 @@ export class ViewService {
   saveFile(file: FileEvents) {
     if (file.data && file.path) {
       invoke<string>('save_file', { path: file.path, data: file.data }).then((res: string) => {
-        console.log("Response from the backend \n", file.data , res);
+        console.debug(res);
       })
     }
   }

--- a/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { invoke } from '@tauri-apps/api';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { FileEvents, FileEventType } from '../../utilities/interfaces/Events';
 import { environment } from '../../../../environments/environment';
 
@@ -15,7 +15,7 @@ export class ViewService {
   /**
    * Give the default path of the text file to be used when nothing is given
    */
-  readFile$ = new BehaviorSubject<FileEvents>({...environment.init_file, type: FileEventType.OPEN});
+  readFile$ = new Subject<FileEvents>();
 
   constructor() {
     this.readFile$.subscribe((event:FileEvents) => {
@@ -49,7 +49,7 @@ export class ViewService {
   saveFile(file: FileEvents) {
     if (file.data && file.path) {
       invoke<string>('save_file', { path: file.path, data: file.data }).then((res: string) => {
-        console.log("Response from the backend ", res);
+        console.log("Response from the backend \n", file.data , res);
       })
     }
   }

--- a/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
@@ -1,23 +1,33 @@
 import { Injectable, signal } from '@angular/core';
 import { invoke } from '@tauri-apps/api';
 import { BehaviorSubject } from 'rxjs';
+import { SaveFileEvent } from '../../utilities/interfaces/Events';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ViewService {
+  workbook$ = new BehaviorSubject<string>(
+    'This is some default \n work from an file',
+  );
 
-    workbook$ = new BehaviorSubject<string>('This is some default \n work from an file')
+  constructor() {}
 
-  constructor() { }
-
-  readFile(pathStr: string) {
-    if(pathStr == ".") return;
-    invoke<string>("read_file", { pathStr }).then((data:string) => {
-           this.workbook$.next(data);
-    })
+  readFile(path: string) {
+    if (path == '.') return this.workbook$.next('This is some default \n work from an file');
+    invoke<string>('read_file', { path }).then((data: string) => {
+      this.workbook$.next(data);
+    });
   }
 
-
-
+  saveFile(file: SaveFileEvent) {
+    if(file.data && file.path ){
+      let path = file.path
+      let data = file.data
+      
+      invoke<string>('save_file',{ path, data }).then((res:string)=>{
+        console.log("Response from the backend ", res);        
+      })
+    }
+  }
 }

--- a/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { invoke } from '@tauri-apps/api';
 import { BehaviorSubject } from 'rxjs';
-import { SaveFileEvent } from '../../utilities/interfaces/Events';
+import { FileEvents, FileEventType } from '../../utilities/interfaces/Events';
+import { environment } from '../../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -11,19 +12,28 @@ export class ViewService {
     'This is some default \n work from an file',
   );
 
-  constructor() { }
+  /**
+   * Give the default path of the text file to be used when nothing is given
+   */
+  readFile$ = new BehaviorSubject<FileEvents>({...environment.init_file, type: FileEventType.OPEN});
+
+  constructor() {
+    this.readFile$.subscribe((event:FileEvents) => {
+      this.readFile(event.path);
+    })
+  }
 
   readFile(path: string | undefined ) {
-    console.log("Reading file with path ", path);
-    
-    // If path is undefined the return with error log 
+    console.debug("Reading file with path ", path);
+
+    // If path is undefined the return with error log
     if( !path ) console.error("Error while opening the file. Path undefined", path);
 
-    // Some default values to be retured for current directory path . TODO Needs to verify if this is required or not :( 
+    // Some default values to be retured for current directory path . TODO Needs to verify if this is required or not :(
     if (path == '.') return this.workbook$.next('This is some default \n work from an file');
 
     /**
-     * Reads the content of the file from the given path 
+     * Reads the content of the file from the given path
      */
     invoke<string>('read_file', { path }).then((data: string) => {
       this.workbook$.next(data);
@@ -33,10 +43,10 @@ export class ViewService {
   /**
    * Saves the file contents on the choosen directory.
    * If the file is not present then creates the file with the specified name and then stores the content .
-   * If the file is present it stores the content in the exsisting file 
-   * @param file 
+   * If the file is present it stores the content in the exsisting file
+   * @param file
    */
-  saveFile(file: SaveFileEvent) {
+  saveFile(file: FileEvents) {
     if (file.data && file.path) {
       invoke<string>('save_file', { path: file.path, data: file.data }).then((res: string) => {
         console.log("Response from the backend ", res);

--- a/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-vew.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { invoke } from '@tauri-apps/api';
 import { BehaviorSubject } from 'rxjs';
 import { SaveFileEvent } from '../../utilities/interfaces/Events';
@@ -11,22 +11,35 @@ export class ViewService {
     'This is some default \n work from an file',
   );
 
-  constructor() {}
+  constructor() { }
 
-  readFile(path: string) {
+  readFile(path: string | undefined ) {
+    console.log("Reading file with path ", path);
+    
+    // If path is undefined the return with error log 
+    if( !path ) console.error("Error while opening the file. Path undefined", path);
+
+    // Some default values to be retured for current directory path . TODO Needs to verify if this is required or not :( 
     if (path == '.') return this.workbook$.next('This is some default \n work from an file');
+
+    /**
+     * Reads the content of the file from the given path 
+     */
     invoke<string>('read_file', { path }).then((data: string) => {
       this.workbook$.next(data);
     });
   }
 
+  /**
+   * Saves the file contents on the choosen directory.
+   * If the file is not present then creates the file with the specified name and then stores the content .
+   * If the file is present it stores the content in the exsisting file 
+   * @param file 
+   */
   saveFile(file: SaveFileEvent) {
-    if(file.data && file.path ){
-      let path = file.path
-      let data = file.data
-      
-      invoke<string>('save_file',{ path, data }).then((res:string)=>{
-        console.log("Response from the backend ", res);        
+    if (file.data && file.path) {
+      invoke<string>('save_file', { path: file.path, data: file.data }).then((res: string) => {
+        console.log("Response from the backend ", res);
       })
     }
   }

--- a/src/app/modules/ui-elements/rusty-view/rusty-view.component.html
+++ b/src/app/modules/ui-elements/rusty-view/rusty-view.component.html
@@ -5,7 +5,7 @@
       <rusty-folder-tree (openFileEvent)="tabs.newTab($event)"></rusty-folder-tree>
     </div>
     <app-tabs #tabs panel2 (activeTabChangeEvent)="updateWorkpad($event)"></app-tabs>
-    <app-workpad panel2 [contentFromFile]="workfile"></app-workpad>
+    <app-workpad panel2 (saveFileEvent)="saveCurrentFile($event)" [contentFromFile]="workfile"></app-workpad>
 
   </app-splitter>
 </div>

--- a/src/app/modules/ui-elements/rusty-view/rusty-view.component.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-view.component.ts
@@ -5,7 +5,7 @@ import { SplitterComponent } from '../splitter/splitter.component';
 import { FolderTreeComponent } from '../folder-tree/folder-tree.component';
 import { ViewService } from './rusty-vew.service';
 import { Subscription } from 'rxjs';
-import { SaveFileEvent, TabChangeEvent } from '../../utilities/interfaces/Events';
+import { FileEvents} from '../../utilities/interfaces/Events';
 import { save } from '@tauri-apps/api/dialog';
 import { environment } from '../../../../environments/environment';
 
@@ -26,7 +26,7 @@ export class RustyViewComponent {
   workFileSubs: Subscription;
   workfilePath: string | undefined = undefined;
   currentWorkingDirectory: string = environment.current_directory;
-  currentFileName:string = "";
+  currentFileName: string | undefined = "";
 
   constructor(private viewService: ViewService) {
     this.workFileSubs = this.viewService.workbook$.subscribe((data) => {
@@ -34,28 +34,28 @@ export class RustyViewComponent {
     });
   }
 
-  updateWorkpad(tabChangeEvent: TabChangeEvent) {
-    this.workfilePath = tabChangeEvent.path;
-    this.currentFileName = tabChangeEvent.file;
-    this.viewService.readFile(tabChangeEvent.path);
+  updateWorkpad(fileEvent: FileEvents) {
+    this.workfilePath = fileEvent.path;
+    this.currentFileName = fileEvent.file_name;
+    this.viewService.readFile$.next(fileEvent);
   }
 
-  saveCurrentFile(event: SaveFileEvent) {
+  saveCurrentFile(event: FileEvents) {
     /**
-     * If current workfile path is not present , then open save dialog on save event 
+     * If current workfile path is not present , then open save dialog on save event
      */
     if (!this.workfilePath) {
-      save({ defaultPath: this.currentWorkingDirectory, title: "Save As"})
+      save({ defaultPath: this.currentWorkingDirectory, title: "Save As" })
         .then((saveFilePath) => {
           console.log("save file path ", saveFilePath);
           if (saveFilePath) {
             this.workfilePath = saveFilePath;
-            this.viewService.saveFile({ ...event, path: saveFilePath as string } as SaveFileEvent);
+            this.viewService.saveFile({ ...event, path: saveFilePath as string } as FileEvents);
           }
         })
     }
     else {
-      this.viewService.saveFile({ ...event, path: this.workfilePath } as SaveFileEvent);
+      this.viewService.saveFile({ ...event, path: this.workfilePath } as FileEvents);
     }
   }
 }

--- a/src/app/modules/ui-elements/rusty-view/rusty-view.component.ts
+++ b/src/app/modules/ui-elements/rusty-view/rusty-view.component.ts
@@ -1,32 +1,41 @@
 import { Component, computed } from '@angular/core';
-import { TabsComponent } from "../tabs/tabs.component";
+import { TabsComponent } from '../tabs/tabs.component';
 import { WorkpadComponent } from '../workpad/workpad.component';
-import { SplitterComponent } from "../splitter/splitter.component";
-import { FolderTreeComponent } from "../folder-tree/folder-tree.component";
+import { SplitterComponent } from '../splitter/splitter.component';
+import { FolderTreeComponent } from '../folder-tree/folder-tree.component';
 import { ViewService } from './rusty-vew.service';
 import { Subscription } from 'rxjs';
+import { SaveFileEvent } from '../../utilities/interfaces/Events';
 
 @Component({
   selector: 'app-rusty-view',
   templateUrl: './rusty-view.component.html',
   styleUrl: './rusty-view.component.scss',
   standalone: true,
-  imports: [TabsComponent, WorkpadComponent, SplitterComponent, FolderTreeComponent]
+  imports: [
+    TabsComponent,
+    WorkpadComponent,
+    SplitterComponent,
+    FolderTreeComponent,
+  ],
 })
 export class RustyViewComponent {
+  workfile!: string;
+  workFileSubs: Subscription;
+  workfilePath: string = '.';
 
-workfile!: string;
-workFileSubs: Subscription;
+  constructor(private viewService: ViewService) {
+    this.workFileSubs = this.viewService.workbook$.subscribe((data) => {
+      this.workfile = data;
+    });
+  }
 
+  updateWorkpad(path: string) {
+    this.workfilePath = path;
+    this.viewService.readFile(path);
+  }
 
-constructor(private viewService:ViewService){
-  this.workFileSubs = this.viewService.workbook$.subscribe((data)=>{
-    this.workfile = data ;
-  })
-}
-
-updateWorkpad(path: string) {
-  this.viewService.readFile(path);
-}
-
+  saveCurrentFile(event: SaveFileEvent) {
+    this.viewService.saveFile({...event, path:this.workfilePath} as SaveFileEvent);
+  }
 }

--- a/src/app/modules/ui-elements/tabs/tabs.component.ts
+++ b/src/app/modules/ui-elements/tabs/tabs.component.ts
@@ -12,6 +12,7 @@ import { WorkpadComponent } from '../workpad/workpad.component';
 import { Tab } from '../../utilities/interfaces/Tab';
 import { NEW_TAB_DEFAULT } from '../../utilities/Constants';
 import { FileEvents, FileEventType} from '../../utilities/interfaces/Events';
+import { environment } from '../../../../environments/environment';
 @Component({
   selector: 'app-tabs',
   templateUrl: './tabs.component.html',
@@ -34,9 +35,10 @@ export class TabsComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.tabs.length == 0) {
-      this.tabs.push({ ...NEW_TAB_DEFAULT, id: 0 })
+      this.tabs.push({ ...NEW_TAB_DEFAULT, id: 0, title: environment.init_file.file_name, path: environment.init_file.path })
       this.activeIndex = 0;
       this.tabs[0].selected = true
+      this.triggerTabChangeEvent(0);
     }
   }
   /**

--- a/src/app/modules/ui-elements/tabs/tabs.component.ts
+++ b/src/app/modules/ui-elements/tabs/tabs.component.ts
@@ -11,7 +11,7 @@ import { CommonModule, NgFor } from '@angular/common';
 import { WorkpadComponent } from '../workpad/workpad.component';
 import { Tab } from '../../utilities/interfaces/Tab';
 import { NEW_TAB_DEFAULT } from '../../utilities/Constants';
-import { OpenFileEvent, TabChangeEvent } from '../../utilities/interfaces/Events';
+import { FileEvents, FileEventType} from '../../utilities/interfaces/Events';
 @Component({
   selector: 'app-tabs',
   templateUrl: './tabs.component.html',
@@ -19,8 +19,8 @@ import { OpenFileEvent, TabChangeEvent } from '../../utilities/interfaces/Events
   standalone: true,
   imports: [CommonModule, TabViewModule, WorkpadComponent, NgFor],
 })
-export class TabsComponent implements OnInit{
-  @Output() activeTabChangeEvent = new EventEmitter<TabChangeEvent>();
+export class TabsComponent implements OnInit {
+  @Output() activeTabChangeEvent = new EventEmitter<FileEvents>();
 
   /**
    * This is use to toggle active tab on Ctrl + Tab event
@@ -30,11 +30,11 @@ export class TabsComponent implements OnInit{
   /**
    * This takes a list of tabs from the service which reads all the files
    */
-  @Input('tabs') tabs: Tab[] = []; 
+  @Input('tabs') tabs: Tab[] = [];
 
   ngOnInit(): void {
-    if(this.tabs.length == 0){
-      this.tabs.push({...NEW_TAB_DEFAULT, id:0})
+    if (this.tabs.length == 0) {
+      this.tabs.push({ ...NEW_TAB_DEFAULT, id: 0 })
       this.activeIndex = 0;
       this.tabs[0].selected = true
     }
@@ -51,9 +51,11 @@ export class TabsComponent implements OnInit{
   /**
    * New Tab on Ctrl + N
    */
-  newTab(tabEvent: OpenFileEvent) {
-    if (!tabEvent.file_name) this.createBlankTab();
-    if (!tabEvent.path) this.createBlankTab();
+  newTab(tabEvent: FileEvents) {
+    if (!tabEvent.file_name || !tabEvent.path) {
+      this.createBlankTab();
+      return;
+    }
 
     let newTab: Tab = {
       ...NEW_TAB_DEFAULT,
@@ -79,6 +81,10 @@ export class TabsComponent implements OnInit{
 
   triggerTabChangeEvent(index: number = 0) {
     if (this.tabs?.length)
-      this.activeTabChangeEvent.emit({ path: this.tabs[index].path, file: this.tabs[index].title});
+      this.activeTabChangeEvent.emit({
+        path: this.tabs[index].path,
+        file_name: this.tabs[index].title,
+        type: FileEventType.TAB_CHANGE
+      });
   }
 }

--- a/src/app/modules/ui-elements/tabs/tabs.component.ts
+++ b/src/app/modules/ui-elements/tabs/tabs.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   Component,
   EventEmitter,
   HostListener,
@@ -12,7 +11,7 @@ import { CommonModule, NgFor } from '@angular/common';
 import { WorkpadComponent } from '../workpad/workpad.component';
 import { Tab } from '../../utilities/interfaces/Tab';
 import { NEW_TAB_DEFAULT } from '../../utilities/Constants';
-import { OpenFileEvent } from '../../utilities/interfaces/Events';
+import { OpenFileEvent, TabChangeEvent } from '../../utilities/interfaces/Events';
 @Component({
   selector: 'app-tabs',
   templateUrl: './tabs.component.html',
@@ -21,7 +20,7 @@ import { OpenFileEvent } from '../../utilities/interfaces/Events';
   imports: [CommonModule, TabViewModule, WorkpadComponent, NgFor],
 })
 export class TabsComponent implements OnInit{
-  @Output() activeTabChangeEvent = new EventEmitter<string>();
+  @Output() activeTabChangeEvent = new EventEmitter<TabChangeEvent>();
 
   /**
    * This is use to toggle active tab on Ctrl + Tab event
@@ -80,6 +79,6 @@ export class TabsComponent implements OnInit{
 
   triggerTabChangeEvent(index: number = 0) {
     if (this.tabs?.length)
-      this.activeTabChangeEvent.emit(this.tabs[index].path);
+      this.activeTabChangeEvent.emit({ path: this.tabs[index].path, file: this.tabs[index].title});
   }
 }

--- a/src/app/modules/ui-elements/workpad/workpad.component.html
+++ b/src/app/modules/ui-elements/workpad/workpad.component.html
@@ -1,4 +1,4 @@
-<p-editor (onInit)="initializeEditor($event)" [spellcheck]="false" class="workpad">
+<p-editor (onTextChange)="handleContentChange($event)" (onInit)="initializeEditor($event)" [spellcheck]="false" class="workpad">
     <ng-template  pTemplate="header">
         <span *ngIf="showHeader" class="ql-formats">
             <button type="button" class="ql-bold" aria-label="Bold"></button>

--- a/src/app/modules/ui-elements/workpad/workpad.component.ts
+++ b/src/app/modules/ui-elements/workpad/workpad.component.ts
@@ -11,7 +11,7 @@ import { CommonModule, NgStyle } from '@angular/common';
 import { EditorInitEvent, EditorModule } from 'primeng/editor';
 import { FormsModule } from '@angular/forms';
 import Quill from 'quill';
-import { SaveFileEvent } from '../../utilities/interfaces/Events';
+import { FileEvents, FileEventType } from '../../utilities/interfaces/Events';
 import { Delta } from 'quill/core';
 @Component({
   selector: 'app-workpad',
@@ -26,7 +26,7 @@ export class WorkpadComponent implements OnChanges {
    */
   @Input('contentFromFile') contentFromFile!: string;
 
-  @Output() saveFileEvent = new EventEmitter<SaveFileEvent>();
+  @Output() saveFileEvent = new EventEmitter<FileEvents>();
 
   supportsQuill: boolean = false;
 
@@ -60,15 +60,16 @@ export class WorkpadComponent implements OnChanges {
       let delta;
       try {
         delta = new Delta(JSON.parse(this.contentFromFile));
-        console.log("delta is ", delta, this.contentFromFile);
-        
         if( !delta.ops.length ) {
           throw new Error("Not a Quill Object ");
         }
-        
+        console.debug("Loading Quill Object ");
+
         this.supportsQuill = true;
         this.quill.setContents(delta);
       } catch (error) {
+        console.debug("Loading normal text Object");
+
         this.quill.setText(this.contentFromFile);
         this.supportsQuill = false;
       }
@@ -82,12 +83,12 @@ export class WorkpadComponent implements OnChanges {
   getCurrentDraf() {
     if (this.quill) {
       if (this.supportsQuill)
-        return this.saveFileEvent.emit({ data: JSON.stringify(this.quill.getContents()) });
+        return this.saveFileEvent.emit({ data: JSON.stringify(this.quill.getContents()), type: FileEventType.SAVE });
       else {
-        return this.saveFileEvent.emit({ data: this.quill.getText() });
+        return this.saveFileEvent.emit({ data: this.quill.getText(), type: FileEventType.SAVE });
       }
     }
-    return this.saveFileEvent.emit({ data: undefined });
+    return this.saveFileEvent.emit({ data: undefined, type: FileEventType.SAVE});
   }
 
 }

--- a/src/app/modules/ui-elements/workpad/workpad.component.ts
+++ b/src/app/modules/ui-elements/workpad/workpad.component.ts
@@ -62,9 +62,9 @@ export class WorkpadComponent implements OnChanges {
    * This is just for debugging purposes
    */
   @HostListener('document:keydown.control.S')
-  getCurrentDraf():string {
+  getCurrentDraf():string|undefined {
     if(this.quill)
       return this.quill.getText()
-    return "";
+    return undefined;
   }
 }

--- a/src/app/modules/utilities/Constants.ts
+++ b/src/app/modules/utilities/Constants.ts
@@ -5,5 +5,5 @@ id: -1,
 isClosable: true,
 selected: true,
 title: "New Tab",
-path: "."
+path: undefined
 }

--- a/src/app/modules/utilities/interfaces/Events.ts
+++ b/src/app/modules/utilities/interfaces/Events.ts
@@ -1,4 +1,9 @@
-export interface OpenFileEvent 
-{ file_name: string,
-     path: string 
-    }
+export interface OpenFileEvent {
+  file_name: string;
+  path: string;
+}
+
+export interface SaveFileEvent {
+     path?: string,
+     data?: string
+}

--- a/src/app/modules/utilities/interfaces/Events.ts
+++ b/src/app/modules/utilities/interfaces/Events.ts
@@ -1,18 +1,3 @@
-export interface OpenFileEvent {
-  file_name: string;
-  path: string;
-}
-
-export interface SaveFileEvent {
-     path?: string,
-     data?: string
-}
-
-export interface TabChangeEvent {
-  path: string | undefined,
-  file: string
-}
-
 export interface FileEvents {
   file_name?:string,
   path?: string | undefined,

--- a/src/app/modules/utilities/interfaces/Events.ts
+++ b/src/app/modules/utilities/interfaces/Events.ts
@@ -12,3 +12,16 @@ export interface TabChangeEvent {
   path: string | undefined,
   file: string
 }
+
+export interface FileEvents {
+  file_name?:string,
+  path?: string | undefined,
+  data?: string
+  type: FileEventType
+}
+
+export enum FileEventType {
+  OPEN,
+  SAVE,
+  TAB_CHANGE,
+}

--- a/src/app/modules/utilities/interfaces/Events.ts
+++ b/src/app/modules/utilities/interfaces/Events.ts
@@ -7,3 +7,8 @@ export interface SaveFileEvent {
      path?: string,
      data?: string
 }
+
+export interface TabChangeEvent {
+  path: string | undefined,
+  file: string
+}

--- a/src/app/modules/utilities/interfaces/Tab.ts
+++ b/src/app/modules/utilities/interfaces/Tab.ts
@@ -3,5 +3,5 @@ export interface Tab{
   title: string,
   isClosable: boolean,
   selected: boolean,
-  path: string
+  path: string | undefined
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,8 @@
 export const environment = {
   prodcution: true,
-  current_directory: "D:\\rusty-workspace\\"
+  current_directory: "D:\\Repo\\personal_repos\\rusty\\rusty-notepad",
+  init_file: {
+    path: "D:\\Repo\\personal_repos\\rusty\\rusty-notepad\\dodo.py",
+    file_name: "dodo.py"
+  }
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  prodcution: true,
+  current_directory: ".\\"
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,4 @@
 export const environment = {
   prodcution: true,
-  current_directory: "D:\\Repo\\personal_repos\\rusty\\rusty-notepad"
+  current_directory: "D:\\rusty-workspace\\"
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,4 @@
 export const environment = {
   prodcution: true,
-  current_directory: ".\\"
+  current_directory: "D:\\Repo\\personal_repos\\rusty\\rusty-notepad"
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  prodcution: true,
+  current_directory: ".\\"
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,8 @@
 export const environment = {
   prodcution: true,
-  current_directory: ".\\"
+  current_directory: ".\\",
+  init_file: {
+    path: "D:\\Repo\\personal_repos\\rusty\\rusty-notepad\\dodo.py",
+    file_name: "dodo.py"
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -23,8 +23,7 @@
   --accent-color: #60a5fa70;
   --higlighter:
 
-  /* Typography */
-  --workpad-font-family: "Courier New";
+  /* Typography */ --workpad-font-family: "Courier New";
   // Color
   --text-color-dark-base: white;
   --text-color-light-base: black;
@@ -62,19 +61,30 @@
       .ql-editor {
         padding: var(--padding-xs);
         // font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Oxygen,
+          Ubuntu,
+          Cantarell,
+          "Open Sans",
+          "Helvetica Neue",
+          sans-serif;
         font-size: 1.1em;
         font-weight: 300;
       }
     }
   }
 
-  // Paddings
+  /* Paddings */
   div.p-tabview-panels {
     padding: var(--padding-xs) 0;
   }
 
-  // Tabs Padding CSS
+  /* Tabs Padding CSS */
   .p-tabview .p-tabview-nav li {
     width: max(100px, 5%);
     .p-tabview-nav-link {
@@ -84,7 +94,6 @@
     }
 
     .p-element.p-icon-wrapper {
-      
       margin-left: auto;
       padding-right: 2px;
     }
@@ -93,18 +102,21 @@
       width: 9px;
     }
   }
-  // Splitter gutter css
-  p-splitter > div{
+
+  /* Splitter gutter css */
+  p-splitter > div {
     div.p-splitter-gutter:hover {
       background: var(--accent-color);
       transition: background-color 0.5s ease;
-      width: .27rem;
+      width: 0.27rem;
     }
     div.p-splitter-gutter {
       width: 2.5px;
     }
   }
 }
+
+/* Global Level Styles for background  */
 * {
   body {
     height: calc(100dvh);
@@ -113,7 +125,8 @@
   }
 }
 // Custom Background per component
-.p-splitter, .p-tabview  * , .p-editor-content * {
-    background-color: var(--workpad-background) !important;
+.p-splitter,
+.p-tabview *,
+.p-editor-content * {
+  background-color: var(--workpad-background) !important;
 }
-

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,11 +32,11 @@
 
   //  Font - Weight
   --font-weight-primary: 200;
-  --font-weight-secondary: 400;
+  --font-weight-secondary: 300;
 
   // Font - Size
   --font-size-primary: 1rem;
-  --font-size-secondary: 0.7rem;
+  --font-size-secondary: 0.8rem;
 
   // paddings and margins
   --padding-xs: 0.25rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -36,7 +36,7 @@
 
   // Font - Size
   --font-size-primary: 1rem;
-  --font-size-secondary: 0.8rem;
+  --font-size-secondary: 0.75rem;
 
   // paddings and margins
   --padding-xs: 0.25rem;


### PR DESCRIPTION
Save Epic :
- [x] Investigate where is the file storage of rust / tauri desktop application 
- [x] Enable saving existing files to the current location
- [x] Enable showing a pop up with files with no path to ask for location 
- [x] Pass in the default path to be taken as the starting for the app 
- [x] Read more about the Tauri dialog api , to read and save new files. https://v2.tauri.app/plugin/dialog/#open-a-file-selector-dialog
- [x] Open Quil specific files based on the content of the file . If not a quill delta file then open as text else render quill data .
- [x] Test with images for save 
- [x] Add a quill save button Alt + S . To save quill specific file and Ctrl + S to save normal text file. 

Testing Action Items 

Normal File Tests 
- [x] Opening a normal document works
- [x] Editing a normal file and then saving has the updated contents
- [x] Creating a new tab and updating it with contents , Saving this tab asks for the file location 
- [x] This new file is saved in the chosen location .
- [x] We can read the contents of the file , 
- [x] This new file has text type documents. 
- [x] Has the same extension as the given one . As in we can create .py , .txt , .ts files as well form the notepad
- [ ] On saving the file Tabs title is updated with the filename and also have set the current path of the file . https://github.com/ApoorvaPasbola/rusty-notepad/issues/21

Quill File Tests 
- [x] Saving a quill document works 
- [x] Opening a quill specific document works 
- [x] Saving a new file with quill contents and then reading it works .
